### PR TITLE
feat: permission hooks / deny-list

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -15,9 +15,11 @@ import { launchpadScrape } from "./tools/launchpad-scrape.js";
 import { browserTask } from "./tools/browser-task.js";
 import { runShell } from "./tools/shell.js";
 import { createContextInfoTool } from "./tools/context-info.js";
+import { manageTodos } from "./tools/todo.js";
 import { transformContext } from "./context.js";
 import { traceTools } from "./tracing.js";
 import { restoreSession } from "./session.js";
+import { checkPermission } from "./permissions.js";
 
 const staticTools: AgentTool[] = [
   // GPU
@@ -38,6 +40,8 @@ const staticTools: AgentTool[] = [
   browserTask,
   // Shell
   runShell,
+  // Todos
+  manageTodos,
 ];
 
 export async function createAgent(): Promise<Agent> {
@@ -89,8 +93,24 @@ export async function createAgent(): Promise<Agent> {
     streamFn: agentWeaveStreamFn,
   });
 
-  // Add agent-bound tools, wrapped with tracing spans
-  const allTools = traceTools([...staticTools, createContextInfoTool(agent)]);
+  // Wrap tools with permission checks before tracing
+  function withPermissionCheck(tool: AgentTool): AgentTool {
+    const originalExecute = tool.execute;
+    return {
+      ...tool,
+      execute: async (toolCallId: string, params: unknown, signal?: AbortSignal, onUpdate?: any) => {
+        const result = await checkPermission(tool.name, params);
+        if (!result.allowed) {
+          log("warn", `Tool call denied: ${tool.name} — ${result.reason}`);
+          return { content: [{ type: "text" as const, text: `Tool call denied: ${result.reason}` }], details: {} };
+        }
+        return originalExecute(toolCallId, params as any, signal, onUpdate);
+      },
+    };
+  }
+
+  // Add agent-bound tools, wrapped with permission checks and tracing spans
+  const allTools = traceTools([...staticTools, createContextInfoTool(agent)].map(withPermissionCheck));
   agent.state.tools = allTools;
 
   // Restore previous session messages

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -33,7 +33,7 @@ let _rules: PermissionRule[] = [...DEFAULT_DENY_RULES];
 async function loadExtraRules(): Promise<void> {
   if (_extraRulesLoaded) return;
   _extraRulesLoaded = true;
-  const permFile = path.join(process.env.HOME!, "max", "permissions.json");
+  const permFile = path.join(process.env.HOME ?? "/tmp", "max", "permissions.json");
   try {
     const raw = await readFile(permFile, "utf-8");
     const extra: PermissionRule[] = JSON.parse(raw);

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,71 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { log } from "./logger.js";
+
+export interface PermissionRule {
+  tool: string;
+  pattern?: string;
+  action: "allow" | "deny";
+  reason?: string;
+}
+
+export const DEFAULT_DENY_RULES: PermissionRule[] = [
+  { tool: "runShell", pattern: "rm -rf", action: "deny", reason: "Recursive force delete is not allowed" },
+  { tool: "runShell", pattern: "sudo rm", action: "deny", reason: "Sudo delete is not allowed" },
+  { tool: "runShell", pattern: "mkfs", action: "deny", reason: "Filesystem formatting is not allowed" },
+  { tool: "runShell", pattern: "format", action: "deny", reason: "Disk formatting is not allowed" },
+  { tool: "runShell", pattern: ":(){:|:&};:", action: "deny", reason: "Fork bomb is not allowed" },
+  { tool: "runShell", pattern: "dd if=", action: "deny", reason: "Direct disk write is not allowed" },
+  { tool: "runShell", pattern: "> /dev/", action: "deny", reason: "Writing to device files is not allowed" },
+  { tool: "sshToNas", pattern: "rm -rf", action: "deny", reason: "Recursive force delete over SSH is not allowed" },
+  { tool: "sshToNas", pattern: "sudo rm", action: "deny", reason: "Sudo delete over SSH is not allowed" },
+  { tool: "sshToNas", pattern: "DROP TABLE", action: "deny", reason: "SQL DROP TABLE is not allowed" },
+  { tool: "sshToNas", pattern: "DROP DATABASE", action: "deny", reason: "SQL DROP DATABASE is not allowed" },
+  { tool: "runShell", pattern: "DROP TABLE", action: "deny", reason: "SQL DROP TABLE is not allowed" },
+  { tool: "runShell", pattern: "DROP DATABASE", action: "deny", reason: "SQL DROP DATABASE is not allowed" },
+  { tool: "writeFileTool", pattern: "/etc/passwd", action: "deny", reason: "Writing to /etc/passwd is not allowed" },
+  { tool: "writeFileTool", pattern: "/etc/shadow", action: "deny", reason: "Writing to /etc/shadow is not allowed" },
+];
+
+let _extraRulesLoaded = false;
+let _rules: PermissionRule[] = [...DEFAULT_DENY_RULES];
+
+async function loadExtraRules(): Promise<void> {
+  if (_extraRulesLoaded) return;
+  _extraRulesLoaded = true;
+  const permFile = path.join(process.env.HOME!, "max", "permissions.json");
+  try {
+    const raw = await readFile(permFile, "utf-8");
+    const extra: PermissionRule[] = JSON.parse(raw);
+    _rules = [...DEFAULT_DENY_RULES, ...extra];
+    log("info", `Loaded ${extra.length} extra permission rules from ${permFile}`);
+  } catch {
+    // File doesn't exist or is invalid — use defaults only
+  }
+}
+
+export async function checkPermission(
+  toolName: string,
+  input: unknown
+): Promise<{ allowed: boolean; reason?: string }> {
+  await loadExtraRules();
+
+  const inputStr = typeof input === "string" ? input : JSON.stringify(input ?? "");
+
+  for (const rule of _rules) {
+    if (rule.tool !== toolName && rule.tool !== "*") continue;
+    if (rule.pattern) {
+      if (!inputStr.includes(rule.pattern)) continue;
+    }
+    if (rule.action === "deny") {
+      const reason = rule.reason ?? `Denied by rule: tool=${rule.tool} pattern=${rule.pattern ?? "*"}`;
+      log("warn", `[permissions] DENIED tool=${toolName} reason="${reason}" input=${inputStr.slice(0, 200)}`);
+      return { allowed: false, reason };
+    }
+    if (rule.action === "allow") {
+      return { allowed: true };
+    }
+  }
+
+  return { allowed: true };
+}


### PR DESCRIPTION
Add a pre-tool permission system to prevent destructive tool calls.

- Creates `src/permissions.ts` with `PermissionRule` interface, `DEFAULT_DENY_RULES`, and `checkPermission()` function
- Loads extra rules from `~/max/permissions.json` if it exists (merged with defaults)
- Integrates into `src/agent.ts`: before each tool executes, calls `checkPermission(toolName, input)`
- If denied: skips execution, injects a tool result with error message "Tool call denied: [reason]"
- Denied calls are logged via `log("warn", ...)`

Closes #12