### PR TITLE
feat: structured TodoTool

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -14,6 +14,7 @@ import { launchpadRunScraper, launchpadDeploy } from "./tools/launchpad.js";
 import { launchpadScrape } from "./tools/launchpad-scrape.js";
 import { browserTask } from "./tools/browser-task.js";
 import { runShell } from "./tools/shell.js";
+import { manageTodos } from "./tools/todo.js";
 import { createContextInfoTool } from "./tools/context-info.js";
 import { transformContext } from "./context.js";
 import { traceTools } from "./tracing.js";
@@ -38,6 +39,8 @@ const staticTools: AgentTool[] = [
   browserTask,
   // Shell
   runShell,
+  // Todos
+  manageTodos,
 ];
 
 export async function createAgent(): Promise<Agent> {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
+import { loadActiveTodos } from "./tools/todo.js";
 
 const MAX_HOME = path.join(process.env.HOME!, "max");
 const MEMORY_DIR = path.join(MAX_HOME, "memory");
@@ -46,7 +47,15 @@ You communicate via Telegram. Your responses are rendered with rich formatting. 
 
 Keep responses concise but visually scannable. Use formatting to create structure, not walls of plain text.`;
 
-  return [soul, longTermMem, formatting, yesterdayMem, todayMem].filter(Boolean).join("\n\n---\n\n");
+  // Append active todos to system prompt
+  const activeTodos = await loadActiveTodos();
+  let todoSection = "";
+  if (activeTodos.length > 0) {
+    const lines = activeTodos.map((t) => `- [${t.status}] ${t.task}`);
+    todoSection = `## Active Tasks\n${lines.join("\n")}`;
+  }
+
+  return [soul, longTermMem, formatting, yesterdayMem, todayMem, todoSection].filter(Boolean).join("\n\n---\n\n");
 }
 
 export async function writeMemoryEvent(event: string): Promise<void> {

--- a/src/tools/todo.ts
+++ b/src/tools/todo.ts
@@ -13,7 +13,7 @@ export interface Todo {
   updatedAt: number;
 }
 
-const TODOS_PATH = path.join(process.env.HOME!, "max", "data", "todos.json");
+const TODOS_PATH = path.join(process.env.HOME ?? "/tmp", "max", "data", "todos.json");
 
 async function readTodos(): Promise<Todo[]> {
   try {

--- a/src/tools/todo.ts
+++ b/src/tools/todo.ts
@@ -1,0 +1,120 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+
+export interface Todo {
+  id: string;
+  task: string;
+  status: "pending" | "in_progress" | "done" | "blocked";
+  createdAt: number;
+  updatedAt: number;
+}
+
+const TODOS_PATH = path.join(process.env.HOME!, "max", "data", "todos.json");
+
+async function readTodos(): Promise<Todo[]> {
+  try {
+    const raw = await readFile(TODOS_PATH, "utf-8");
+    return JSON.parse(raw) as Todo[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeTodos(todos: Todo[]): Promise<void> {
+  const dir = path.dirname(TODOS_PATH);
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+  await writeFile(TODOS_PATH, JSON.stringify(todos, null, 2), "utf-8");
+}
+
+export async function loadActiveTodos(): Promise<Todo[]> {
+  const todos = await readTodos();
+  return todos.filter((t) => t.status === "pending" || t.status === "in_progress");
+}
+
+export const manageTodos: AgentTool = {
+  name: "manage_todos",
+  label: "Manage Todos",
+  description: "Manage a persistent todo list. Supports list, add, update, and clear_done actions.",
+  parameters: Type.Object({
+    action: Type.Union([
+      Type.Literal("list"),
+      Type.Literal("add"),
+      Type.Literal("update"),
+      Type.Literal("clear_done"),
+    ], { description: "Action to perform" }),
+    task: Type.Optional(Type.String({ description: "Task description (required for add)" })),
+    id: Type.Optional(Type.String({ description: "Todo ID (required for update)" })),
+    status: Type.Optional(Type.Union([
+      Type.Literal("pending"),
+      Type.Literal("in_progress"),
+      Type.Literal("done"),
+      Type.Literal("blocked"),
+    ], { description: "New status (required for update)" })),
+  }),
+  execute: async (_toolCallId: string, params: unknown) => {
+    const { action, task, id, status } = params as {
+      action: string;
+      task?: string;
+      id?: string;
+      status?: string;
+    };
+
+    const todos = await readTodos();
+
+    if (action === "list") {
+      if (todos.length === 0) {
+        return { content: [{ type: "text" as const, text: "No todos found." }], details: {} };
+      }
+      const lines = todos.map(
+        (t) => `[${t.id.slice(0, 8)}] [${t.status}] ${t.task}`
+      );
+      return { content: [{ type: "text" as const, text: lines.join("\n") }], details: {} };
+    }
+
+    if (action === "add") {
+      if (!task) {
+        return { content: [{ type: "text" as const, text: "Error: task is required for add" }], details: {} };
+      }
+      const now = Date.now();
+      const todo: Todo = {
+        id: randomUUID(),
+        task,
+        status: "pending",
+        createdAt: now,
+        updatedAt: now,
+      };
+      todos.push(todo);
+      await writeTodos(todos);
+      return { content: [{ type: "text" as const, text: `Added todo: [${todo.id.slice(0, 8)}] ${todo.task}` }], details: {} };
+    }
+
+    if (action === "update") {
+      if (!id || !status) {
+        return { content: [{ type: "text" as const, text: "Error: id and status are required for update" }], details: {} };
+      }
+      const todo = todos.find((t) => t.id.startsWith(id));
+      if (!todo) {
+        return { content: [{ type: "text" as const, text: `Error: todo not found with id prefix: ${id}` }], details: {} };
+      }
+      todo.status = status as Todo["status"];
+      todo.updatedAt = Date.now();
+      await writeTodos(todos);
+      return { content: [{ type: "text" as const, text: `Updated [${todo.id.slice(0, 8)}] to ${status}` }], details: {} };
+    }
+
+    if (action === "clear_done") {
+      const before = todos.length;
+      const remaining = todos.filter((t) => t.status !== "done");
+      await writeTodos(remaining);
+      return { content: [{ type: "text" as const, text: `Cleared ${before - remaining.length} done todo(s).` }], details: {} };
+    }
+
+    return { content: [{ type: "text" as const, text: `Unknown action: ${action}` }], details: {} };
+  },
+};


### PR DESCRIPTION
Add a persistent todo list tool that survives context compaction.

**Changes:**
- Creates `src/tools/todo.ts` with `Todo` interface and `manage_todos` tool
- Storage at `~/max/data/todos.json`
- Supports actions: `list`, `add`, `update`, `clear_done`
- Updates `src/memory.ts`: `loadMemory()` appends pending/in_progress todos to the system prompt under `## Active Tasks`
- Registers `manageTodos` in `staticTools` in `src/agent.ts`

Closes #13