### PR TITLE
fix: prevent stale previous reply fallback

### DIFF
--- a/src/a2a-server.ts
+++ b/src/a2a-server.ts
@@ -5,6 +5,7 @@ import { createTask, updateTaskStatus, getRecentTasks, getDb } from "./task-jour
 import { setAgentWeaveSession, resetAgentWeaveSession } from "./agentweave-context.js";
 import { log } from "./logger.js";
 import { saveSession } from "./session.js";
+import { extractAssistantTextFromTurn } from "./response.js";
 
 const A2A_PORT = parseInt(process.env.A2A_PORT || "8770", 10);
 const A2A_SHARED_SECRET = process.env.A2A_SHARED_SECRET || "";
@@ -119,6 +120,7 @@ export function createA2AServer(agent: Agent): express.Express {
 
       // Run agent
       let responseText = "";
+      const turnStartIndex = agent.state.messages.length;
       const unsub = agent.subscribe((event: AgentEvent) => {
         if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
           responseText += event.assistantMessageEvent.delta;
@@ -129,13 +131,7 @@ export function createA2AServer(agent: Agent): express.Express {
       unsub();
 
       if (!responseText) {
-        const lastMsg = agent.state.messages[agent.state.messages.length - 1];
-        if (lastMsg && "content" in lastMsg && lastMsg.role === "assistant") {
-          responseText = lastMsg.content
-            .filter((c): c is { type: "text"; text: string } => c.type === "text")
-            .map((c) => c.text)
-            .join("");
-        }
+        responseText = extractAssistantTextFromTurn(agent.state.messages as any, turnStartIndex);
       }
 
       updateTaskStatus(task.id, "completed", { response: responseText });
@@ -245,18 +241,12 @@ export function createA2AServer(agent: Agent): express.Express {
         }
       });
 
+      const turnStartIndex = agent.state.messages.length;
       await agent.prompt(text);
       unsub();
 
-      // Extract final response
-      let responseText = "";
-      const lastMsg = agent.state.messages[agent.state.messages.length - 1];
-      if (lastMsg && "content" in lastMsg && lastMsg.role === "assistant") {
-        responseText = lastMsg.content
-          .filter((c): c is { type: "text"; text: string } => c.type === "text")
-          .map((c) => c.text)
-          .join("");
-      }
+      // Extract final response from this turn only
+      const responseText = extractAssistantTextFromTurn(agent.state.messages as any, turnStartIndex);
 
       updateTaskStatus(task.id, "completed", { response: responseText });
       saveSession(agent);

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,0 +1,26 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+/**
+ * Extract assistant text from messages produced during the current prompt only.
+ *
+ * This prevents reusing a stale assistant reply from earlier turns when a prompt
+ * yields no streamed text deltas and no new assistant text message.
+ */
+export function extractAssistantTextFromTurn(messages: AgentMessage[], startIndex: number): string {
+  const newMessages = messages.slice(Math.max(0, startIndex));
+
+  for (let i = newMessages.length - 1; i >= 0; i--) {
+    const msg: any = newMessages[i];
+    if (msg?.role !== "assistant" || !Array.isArray(msg.content)) continue;
+
+    const text = msg.content
+      .filter((c: any): c is { type: "text"; text: string } => c?.type === "text" && typeof c.text === "string")
+      .map((c: any) => c.text)
+      .join("")
+      .trim();
+
+    if (text.length > 0) return text;
+  }
+
+  return "";
+}

--- a/src/telegram-bot.ts
+++ b/src/telegram-bot.ts
@@ -6,6 +6,7 @@ import { createTask, updateTaskStatus, getRecentTasks } from "./task-journal.js"
 import { log } from "./logger.js";
 import { traceAgentTurn } from "./tracing.js";
 import { saveSession, clearSession } from "./session.js";
+import { extractAssistantTextFromTurn } from "./response.js";
 
 // ── Deduplication — Issue #2 ─────────────────────────────────────────────────
 const processedUpdateIds = new Set<number>();
@@ -457,6 +458,7 @@ export function createTelegramBot(agent: Agent): Bot {
         }
       });
 
+      const turnStartIndex = agent.state.messages.length;
       startEditing();
       await agent.prompt(text, images);
       unsub();
@@ -466,13 +468,7 @@ export function createTelegramBot(agent: Agent): Bot {
       if (pendingStatusEdit) clearTimeout(pendingStatusEdit);
 
       if (!responseText) {
-        const lastMsg = agent.state.messages[agent.state.messages.length - 1];
-        if (lastMsg && "content" in lastMsg && lastMsg.role === "assistant") {
-          responseText = lastMsg.content
-            .filter((c): c is { type: "text"; text: string } => c.type === "text")
-            .map((c) => c.text)
-            .join("");
-        }
+        responseText = extractAssistantTextFromTurn(agent.state.messages as any, turnStartIndex);
       }
 
       if (!responseText) {

--- a/tests/response.test.ts
+++ b/tests/response.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "@jest/globals";
+import { extractAssistantTextFromTurn } from "../src/response.js";
+
+describe("extractAssistantTextFromTurn", () => {
+  it("returns assistant text from current turn", () => {
+    const messages: any[] = [
+      { role: "user", content: [{ type: "text", text: "old q" }] },
+      { role: "assistant", content: [{ type: "text", text: "old a" }] },
+      { role: "user", content: [{ type: "text", text: "new q" }] },
+      { role: "assistant", content: [{ type: "text", text: "new a" }] },
+    ];
+
+    expect(extractAssistantTextFromTurn(messages as any, 2)).toBe("new a");
+  });
+
+  it("does not return stale previous-turn assistant text", () => {
+    const messages: any[] = [
+      { role: "user", content: [{ type: "text", text: "old q" }] },
+      { role: "assistant", content: [{ type: "text", text: "max via mux finally fixed" }] },
+      { role: "user", content: [{ type: "text", text: "new q" }] },
+      { role: "toolCall", content: [] },
+      { role: "toolResult", content: [{ type: "text", text: "ok" }] },
+    ];
+
+    expect(extractAssistantTextFromTurn(messages as any, 2)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- fix stale reply reuse when no text deltas are emitted for a turn
- only extract fallback assistant text from messages created during the *current* prompt
- apply this in Telegram handler and both A2A endpoints
- add unit tests for turn-scoped extraction behavior

## Root cause
When streamed `text_delta` was empty, code fell back to `agent.state.messages[agent.state.messages.length - 1]` from global history.
If the current turn produced no assistant text message, this could return the previous turn's assistant message (stale reply).

## Validation
- `npm test -- --runInBand tests/response.test.ts` ✅
- Full repo test/build currently fail in this environment due existing `agentweave` module resolution in tracing tests/tsc (pre-existing, unrelated to this change)

Closes #21