### PR TITLE
feat: per-task USD budget cap for background tasks (#3)

### DIFF
--- a/src/a2a-server.ts
+++ b/src/a2a-server.ts
@@ -11,6 +11,7 @@ import {
   appendActivity,
   getUnreportedActivity,
   advanceReportedSeq,
+  setActualCost,
 } from "./task-journal.js";
 import { setAgentWeaveSession, resetAgentWeaveSession } from "./agentweave-context.js";
 import { log } from "./logger.js";
@@ -23,6 +24,25 @@ import { receiveCallback } from "./tools/claude-subagent.js";
 const A2A_PORT = parseInt(process.env.A2A_PORT || "8770", 10);
 const A2A_SHARED_SECRET = process.env.A2A_SHARED_SECRET || "";
 const startTime = Date.now();
+
+/**
+ * Default per-task USD spend cap for async A2A worker tasks. Overridable by
+ * the dispatcher per task via params.metadata.maxBudgetUsd. A 0 or negative
+ * cap disables enforcement for that task.
+ */
+function defaultBudgetCapUsd(): number {
+  const raw = parseFloat(process.env.MAX_DEFAULT_BUDGET_USD || "0.50");
+  return Number.isFinite(raw) ? raw : 0.5;
+}
+
+function resolveBudgetCap(metadata: unknown): number | null {
+  const m = metadata as { maxBudgetUsd?: number; max_budget_usd?: number } | null | undefined;
+  const raw = m?.maxBudgetUsd ?? m?.max_budget_usd;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return raw <= 0 ? null : raw;
+  }
+  return defaultBudgetCapUsd();
+}
 
 const AGENTWEAVE_MAX_PROXY = process.env.AGENTWEAVE_PROXY_URL || "http://arnabsnas.local:30400";
 
@@ -122,7 +142,10 @@ export function createA2AServer(agent: Agent): express.Express {
       const isSync = String(req.query.sync || "false").toLowerCase() === "true";
       log("info", `A2A task from ${callerAgentId || "unknown"} (${isSync ? "sync" : "async"}): ${text.slice(0, 100)}`);
 
-      const task = createTask("a2a_task", "nix", { text, metadata: params.metadata });
+      // Async tasks get a USD spend cap; sync tasks inherit caller's request
+      // lifetime so a budget enforcement abort there would just be confusing.
+      const budgetCapUsd = isSync ? null : resolveBudgetCap(params.metadata);
+      const task = createTask("a2a_task", "nix", { text, metadata: params.metadata }, { budgetCapUsd });
       taskId = task.id;
       updateTaskStatus(task.id, "working");
 
@@ -142,6 +165,7 @@ export function createA2AServer(agent: Agent): express.Express {
               callerAgentId,
               taskLabel,
               traceHeaders,
+              maxBudgetUsd: budgetCapUsd,
             },
           });
 
@@ -155,6 +179,7 @@ export function createA2AServer(agent: Agent): express.Express {
                 void drainActivityToTelegram(task.id);
               }
             } else if (event.type === "complete") {
+              if (typeof event.costUsd === "number") setActualCost(task.id, event.costUsd);
               updateTaskStatus(task.id, "completed", { response: event.result || "" });
               if (!isSilent) {
                 void relayJobCompletionToTelegram({
@@ -166,6 +191,7 @@ export function createA2AServer(agent: Agent): express.Express {
               }
               worker.terminate().catch(() => {});
             } else if (event.type === "error") {
+              if (typeof event.costUsd === "number") setActualCost(task.id, event.costUsd);
               updateTaskStatus(task.id, "failed", { error: event.error || "Unknown error" });
               if (!isSilent) {
                 void relayJobCompletionToTelegram({

--- a/src/task-journal.ts
+++ b/src/task-journal.ts
@@ -21,6 +21,8 @@ export interface TaskRecord {
   updated_at: number;
   retry_count: number;
   last_reported_seq: number;
+  budget_cap_usd: number | null;
+  actual_cost_usd: number | null;
 }
 
 export interface TaskActivity {
@@ -47,7 +49,9 @@ export function getDb(): Database.Database {
         created_at        INTEGER NOT NULL,
         updated_at        INTEGER NOT NULL,
         retry_count       INTEGER NOT NULL DEFAULT 0,
-        last_reported_seq INTEGER NOT NULL DEFAULT 0
+        last_reported_seq INTEGER NOT NULL DEFAULT 0,
+        budget_cap_usd    REAL,
+        actual_cost_usd   REAL
       );
 
       CREATE TABLE IF NOT EXISTS task_activity (
@@ -68,10 +72,19 @@ export function getDb(): Database.Database {
       );
     `);
 
-    // Backfill: existing prod DBs predate last_reported_seq.
+    // Backfill columns added after the original schema. PRAGMA table_info
+    // is the cheapest "does this column exist?" check; ALTER TABLE ADD COLUMN
+    // doesn't have an IF NOT EXISTS clause in SQLite.
     const cols = db.prepare(`PRAGMA table_info(tasks)`).all() as { name: string }[];
-    if (!cols.some((c) => c.name === "last_reported_seq")) {
+    const colNames = new Set(cols.map((c) => c.name));
+    if (!colNames.has("last_reported_seq")) {
       db.exec(`ALTER TABLE tasks ADD COLUMN last_reported_seq INTEGER NOT NULL DEFAULT 0`);
+    }
+    if (!colNames.has("budget_cap_usd")) {
+      db.exec(`ALTER TABLE tasks ADD COLUMN budget_cap_usd REAL`);
+    }
+    if (!colNames.has("actual_cost_usd")) {
+      db.exec(`ALTER TABLE tasks ADD COLUMN actual_cost_usd REAL`);
     }
   }
   return db;
@@ -90,8 +103,18 @@ export function _resetDbForTest(): void {
   db = null;
 }
 
-export function createTask(type: TaskType, source: TaskSource, payload: unknown): TaskRecord {
+export interface CreateTaskOptions {
+  budgetCapUsd?: number | null;
+}
+
+export function createTask(
+  type: TaskType,
+  source: TaskSource,
+  payload: unknown,
+  options: CreateTaskOptions = {}
+): TaskRecord {
   const now = Date.now();
+  const budgetCapUsd = options.budgetCapUsd ?? null;
   const task: TaskRecord = {
     id: randomUUID(),
     type,
@@ -103,14 +126,27 @@ export function createTask(type: TaskType, source: TaskSource, payload: unknown)
     updated_at: now,
     retry_count: 0,
     last_reported_seq: 0,
+    budget_cap_usd: budgetCapUsd,
+    actual_cost_usd: null,
   };
 
   getDb()
     .prepare(
-      `INSERT INTO tasks (id, type, source, payload, status, result, created_at, updated_at, retry_count)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO tasks (id, type, source, payload, status, result, created_at, updated_at, retry_count, budget_cap_usd)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
-    .run(task.id, task.type, task.source, task.payload, task.status, task.result, task.created_at, task.updated_at, task.retry_count);
+    .run(
+      task.id,
+      task.type,
+      task.source,
+      task.payload,
+      task.status,
+      task.result,
+      task.created_at,
+      task.updated_at,
+      task.retry_count,
+      budgetCapUsd
+    );
 
   return task;
 }
@@ -119,6 +155,12 @@ export function updateTaskStatus(id: string, status: TaskStatus, result?: unknow
   getDb()
     .prepare(`UPDATE tasks SET status = ?, result = ?, updated_at = ? WHERE id = ?`)
     .run(status, result ? JSON.stringify(result) : null, Date.now(), id);
+}
+
+export function setActualCost(id: string, costUsd: number): void {
+  getDb()
+    .prepare(`UPDATE tasks SET actual_cost_usd = ?, updated_at = ? WHERE id = ?`)
+    .run(costUsd, Date.now(), id);
 }
 
 export function getIncompleteTasks(): TaskRecord[] {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,6 +15,10 @@ export interface WorkerProgressEvent {
   message?: string;
   result?: string;
   error?: string;
+  /** Cumulative cost in USD at terminal events (complete/error). */
+  costUsd?: number;
+  /** True when termination was caused by exceeding the per-task budget cap. */
+  budgetExceeded?: boolean;
 }
 
 interface WorkerTaskData {
@@ -26,6 +30,19 @@ interface WorkerTaskData {
   taskLabel?: string;
   /** Serialized W3C trace headers (e.g. traceparent) from the calling agent. */
   traceHeaders?: Record<string, string>;
+  /** Per-task USD spend cap. When exceeded, the agent is aborted. */
+  maxBudgetUsd?: number | null;
+}
+
+/**
+ * Extract USD cost from a turn_end event. Returns 0 for non-assistant turns
+ * or messages without usage data. Pure helper, exported for tests.
+ */
+export function costFromTurnEnd(message: unknown): number {
+  if (!message || typeof message !== "object") return 0;
+  const m = message as { role?: string; usage?: { cost?: { total?: number } } };
+  if (m.role !== "assistant") return 0;
+  return m.usage?.cost?.total ?? 0;
 }
 
 async function postProgress(event: WorkerProgressEvent): Promise<void> {
@@ -33,7 +50,7 @@ async function postProgress(event: WorkerProgressEvent): Promise<void> {
 }
 
 async function main() {
-  const { taskId, text, parentSessionId, delegatedSessionId, callerAgentId, taskLabel, traceHeaders } = workerData as WorkerTaskData;
+  const { taskId, text, parentSessionId, delegatedSessionId, callerAgentId, taskLabel, traceHeaders, maxBudgetUsd } = workerData as WorkerTaskData;
 
   // Re-extract trace context from serialized headers so this worker's spans
   // are linked as children of the calling agent's trace.
@@ -42,6 +59,8 @@ async function main() {
     : context.active();
   const AGENTWEAVE_PROXY_TOKEN = process.env.AGENTWEAVE_PROXY_TOKEN;
 
+  // Hoisted so the catch block can include accumulated cost in its error event.
+  let cumulativeCostUsd = 0;
   await context.with(incomingContext, async () => {
   try {
     await postProgress({ type: "progress", taskId, message: "Worker started" });
@@ -70,6 +89,7 @@ async function main() {
 
     const agent = await createAgent();
     let responseText = "";
+    let budgetExceeded = false;
 
     const unsub = agent.subscribe((event: AgentEvent) => {
       if (event.type === "tool_execution_start") {
@@ -78,10 +98,43 @@ async function main() {
       if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
         responseText += event.assistantMessageEvent.delta;
       }
+      if (event.type === "turn_end") {
+        cumulativeCostUsd += costFromTurnEnd(event.message);
+        if (
+          typeof maxBudgetUsd === "number" &&
+          maxBudgetUsd > 0 &&
+          !budgetExceeded &&
+          cumulativeCostUsd > maxBudgetUsd
+        ) {
+          budgetExceeded = true;
+          log(
+            "warn",
+            `Task ${taskId} exceeded budget cap: $${cumulativeCostUsd.toFixed(4)} > $${maxBudgetUsd.toFixed(2)} — aborting`
+          );
+          agent.abort();
+        }
+      }
     });
 
     await agent.prompt(text);
     unsub();
+
+    if (budgetExceeded) {
+      saveSession(agent);
+      emitSessionArtifact({
+        topic: taskLabel || text.slice(0, 80),
+        projects: inferProjectsFromText(text),
+        type: "maintenance",
+      });
+      await postProgress({
+        type: "error",
+        taskId,
+        error: `Budget exceeded: $${cumulativeCostUsd.toFixed(4)} of $${(maxBudgetUsd as number).toFixed(2)} cap`,
+        costUsd: cumulativeCostUsd,
+        budgetExceeded: true,
+      });
+      return;
+    }
 
     if (!responseText) {
       const lastMsg = agent.state.messages[agent.state.messages.length - 1];
@@ -104,7 +157,12 @@ async function main() {
           projects: inferProjectsFromText(text),
           type: "maintenance",
         });
-        await postProgress({ type: "error", taskId, error: `LLM error: ${lastMsg.errorMessage}` });
+        await postProgress({
+          type: "error",
+          taskId,
+          error: `LLM error: ${lastMsg.errorMessage}`,
+          costUsd: cumulativeCostUsd,
+        });
         return;
       }
     }
@@ -115,14 +173,25 @@ async function main() {
       projects: inferProjectsFromText(text),
       type: "coding",
     });
-    await postProgress({ type: "complete", taskId, message: "Worker completed", result: responseText });
+    await postProgress({
+      type: "complete",
+      taskId,
+      message: "Worker completed",
+      result: responseText,
+      costUsd: cumulativeCostUsd,
+    });
   } catch (e: any) {
     emitSessionArtifact({
       topic: taskLabel || text.slice(0, 80),
       projects: inferProjectsFromText(text),
       type: "maintenance",
     });
-    await postProgress({ type: "error", taskId, error: e?.message || String(e) });
+    await postProgress({
+      type: "error",
+      taskId,
+      error: e?.message || String(e),
+      costUsd: cumulativeCostUsd,
+    });
   } finally {
     if (parentSessionId) {
       resetAgentWeaveSession();
@@ -145,4 +214,9 @@ async function main() {
   }); // end context.with
 }
 
-void main();
+// Only auto-run when actually loaded as a worker thread (parentPort exists
+// and workerData is set). Lets tests import pure helpers from this file
+// without spinning up the agent.
+if (parentPort && workerData) {
+  void main();
+}

--- a/tests/a2a-callback.test.ts
+++ b/tests/a2a-callback.test.ts
@@ -18,6 +18,7 @@ jest.unstable_mockModule("../src/task-journal.js", () => ({
   appendActivity: jest.fn().mockReturnValue({ seq: 1 }),
   getUnreportedActivity: jest.fn().mockReturnValue([]),
   advanceReportedSeq: jest.fn(),
+  setActualCost: jest.fn(),
 }));
 
 jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));

--- a/tests/a2a-trace-propagation.test.ts
+++ b/tests/a2a-trace-propagation.test.ts
@@ -28,6 +28,7 @@ jest.unstable_mockModule("../src/task-journal.js", () => ({
   appendActivity: jest.fn().mockReturnValue({ seq: 1 }),
   getUnreportedActivity: jest.fn().mockReturnValue([]),
   advanceReportedSeq: jest.fn(),
+  setActualCost: jest.fn(),
 }));
 jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
 jest.unstable_mockModule("../src/session.js", () => ({

--- a/tests/task-journal.test.ts
+++ b/tests/task-journal.test.ts
@@ -112,3 +112,89 @@ describe("task-journal activity watermarking", () => {
     expect(row.last_reported_seq).toBe(0);
   });
 });
+
+describe("task-journal budget cap persistence", () => {
+  it("createTask with budgetCapUsd persists the cap and starts cost null", async () => {
+    const { createTask, getDb } = await import("../src/task-journal.js");
+    const task = createTask("a2a_task", "nix", { text: "x" }, { budgetCapUsd: 0.25 });
+    const row = getDb()
+      .prepare(`SELECT budget_cap_usd, actual_cost_usd FROM tasks WHERE id = ?`)
+      .get(task.id) as { budget_cap_usd: number; actual_cost_usd: number | null };
+    expect(row.budget_cap_usd).toBeCloseTo(0.25);
+    expect(row.actual_cost_usd).toBeNull();
+  });
+
+  it("createTask without options leaves budget_cap_usd null", async () => {
+    const { createTask, getDb } = await import("../src/task-journal.js");
+    const task = createTask("a2a_task", "nix", { text: "x" });
+    const row = getDb()
+      .prepare(`SELECT budget_cap_usd FROM tasks WHERE id = ?`)
+      .get(task.id) as { budget_cap_usd: number | null };
+    expect(row.budget_cap_usd).toBeNull();
+  });
+
+  it("setActualCost writes the cost to the task row", async () => {
+    const { createTask, setActualCost, getDb } = await import("../src/task-journal.js");
+    const task = createTask("a2a_task", "nix", { text: "x" }, { budgetCapUsd: 0.5 });
+    setActualCost(task.id, 0.1234);
+    const row = getDb()
+      .prepare(`SELECT actual_cost_usd FROM tasks WHERE id = ?`)
+      .get(task.id) as { actual_cost_usd: number };
+    expect(row.actual_cost_usd).toBeCloseTo(0.1234);
+  });
+
+  it("schema migration is idempotent against an existing DB without budget cols", async () => {
+    // Simulate an older prod DB: open with raw sqlite + the original schema,
+    // then let our getDb() open it and perform the ALTER backfills.
+    const Database = (await import("better-sqlite3")).default;
+    const dbFile = process.env.MAX_DB_PATH!;
+    const raw = new Database(dbFile);
+    raw.exec(`
+      CREATE TABLE tasks (
+        id          TEXT PRIMARY KEY,
+        type        TEXT NOT NULL,
+        source      TEXT NOT NULL,
+        payload     TEXT NOT NULL,
+        status      TEXT NOT NULL,
+        result      TEXT,
+        created_at  INTEGER NOT NULL,
+        updated_at  INTEGER NOT NULL,
+        retry_count INTEGER DEFAULT 0
+      );
+      INSERT INTO tasks VALUES ('legacy-1', 'a2a_task', 'nix', '{}', 'completed', null, 0, 0, 0);
+    `);
+    raw.close();
+
+    const { _resetDbForTest, getDb, createTask, setActualCost } = await import(
+      "../src/task-journal.js"
+    );
+    _resetDbForTest();
+
+    // Trigger migration
+    const cols = getDb()
+      .prepare(`PRAGMA table_info(tasks)`)
+      .all() as { name: string }[];
+    const colNames = new Set(cols.map((c) => c.name));
+    expect(colNames.has("last_reported_seq")).toBe(true);
+    expect(colNames.has("budget_cap_usd")).toBe(true);
+    expect(colNames.has("actual_cost_usd")).toBe(true);
+
+    // Existing legacy row has null budget_cap_usd, defaulted last_reported_seq = 0
+    const legacy = getDb()
+      .prepare(
+        `SELECT last_reported_seq, budget_cap_usd, actual_cost_usd FROM tasks WHERE id = 'legacy-1'`
+      )
+      .get() as {
+      last_reported_seq: number;
+      budget_cap_usd: number | null;
+      actual_cost_usd: number | null;
+    };
+    expect(legacy.last_reported_seq).toBe(0);
+    expect(legacy.budget_cap_usd).toBeNull();
+    expect(legacy.actual_cost_usd).toBeNull();
+
+    // Post-migration, new operations work
+    const t = createTask("a2a_task", "nix", { text: "post" }, { budgetCapUsd: 1 });
+    setActualCost(t.id, 0.5);
+  });
+});

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -104,6 +104,43 @@ describe("Telegram relay message format", () => {
 
 import { _clearJobsForTest, _addJobForTest } from "../src/tools/claude-subagent.js";
 
+// ─── Budget cap cost extraction ───────────────────────────────────────────────
+
+import { costFromTurnEnd } from "../src/worker.js";
+
+describe("costFromTurnEnd", () => {
+  it("returns 0 for null/undefined", () => {
+    expect(costFromTurnEnd(null)).toBe(0);
+    expect(costFromTurnEnd(undefined)).toBe(0);
+  });
+
+  it("returns 0 for non-assistant messages", () => {
+    expect(costFromTurnEnd({ role: "user", content: "hi" })).toBe(0);
+    expect(costFromTurnEnd({ role: "toolResult", content: [] })).toBe(0);
+  });
+
+  it("returns 0 when usage is missing", () => {
+    expect(costFromTurnEnd({ role: "assistant" })).toBe(0);
+    expect(costFromTurnEnd({ role: "assistant", usage: {} })).toBe(0);
+    expect(costFromTurnEnd({ role: "assistant", usage: { cost: {} } })).toBe(0);
+  });
+
+  it("returns the total cost from an assistant message usage", () => {
+    const msg = {
+      role: "assistant",
+      usage: {
+        input: 100,
+        output: 200,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 300,
+        cost: { input: 0.01, output: 0.05, cacheRead: 0, cacheWrite: 0, total: 0.06 },
+      },
+    };
+    expect(costFromTurnEnd(msg)).toBeCloseTo(0.06);
+  });
+});
+
 describe("DelegateJob silent flag", () => {
   it("silent=true is preserved in job object", () => {
     _clearJobsForTest();


### PR DESCRIPTION
Closes #3.

## Summary
- New `tasks.budget_cap_usd` and `tasks.actual_cost_usd` columns (idempotent `ALTER TABLE` migration alongside the #4 watermark column)
- `createTask(..., { budgetCapUsd })` writes the cap; `setActualCost(id, usd)` writes the spend
- Worker subscribes to `turn_end`, sums `AssistantMessage.usage.cost.total` per turn, and calls `agent.abort()` when the running total crosses the cap; emits an \"error\" event with \"Budget exceeded: \$X.XXXX of \$Y.YY cap\"
- A2A `POST /tasks` reads `params.metadata.maxBudgetUsd` (also accepts `max_budget_usd`). Default comes from `MAX_DEFAULT_BUDGET_USD` env (fallback 0.50). Pass `<= 0` to disable. Sync tasks skip the cap (caller's request lifetime governs)
- Worker terminal events (`complete`/`error`) now carry `costUsd` so the parent thread persists actual spend before relaying to Telegram
- Existing `relayJobCompletionToTelegram` already surfaces failure messages, so the cap-exceeded path drops out of \"Telegram on budget exceeded\" with no new code

## Why now
Per #3: a runaway loop in a background scrape/deploy/analysis task could burn meaningful API budget unattended. The cap is the floor under that.

## Scope note
Cost enforcement only applies to A2A worker-thread tasks (Max's own LLM calls, visible via pi-ai's `Usage.cost.total`). The Claude subagent path runs a child Claude CLI whose API calls are opaque to Max, so cost can't be measured at this layer — out of scope for this PR.

## Test plan
- [x] `costFromTurnEnd` unit tests — null/undefined, non-assistant, missing usage, populated total
- [x] Schema migration test against an older DB (raw sqlite seed without the new columns) confirms idempotent ALTER + legacy rows get NULL caps and `last_reported_seq=0`
- [x] `createTask` with/without `budgetCapUsd`, plus `setActualCost` round-trip
- [x] Full suite (97 tests) green; existing ESM mock tests updated for new `setActualCost` export
- [ ] Smoke on Mac Mini after deploy: kick a Nix → Max async task with `metadata.maxBudgetUsd: 0.01` and confirm it aborts + Telegram says \"Budget exceeded\"

## Notes
- Test seam: `worker.ts` now guards its auto-run behind `parentPort && workerData` so tests can import pure helpers without booting an agent
- Cap is checked **after** each turn, so a single round-trip that on its own exceeds the cap will go over once and stop on the next call. Acceptable trade for not requiring streaming-cost hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)