### PR TITLE
Fix Max session isolation and trace attribution

### DIFF
--- a/src/a2a-server.ts
+++ b/src/a2a-server.ts
@@ -13,9 +13,9 @@ import {
   advanceReportedSeq,
   setActualCost,
 } from "./task-journal.js";
-import { setAgentWeaveSession, resetAgentWeaveSession } from "./agentweave-context.js";
+import { makeA2ASessionContext, makeTuiSessionContext, withSessionContext, type SessionContext } from "./agentweave-context.js";
 import { log } from "./logger.js";
-import { saveSession } from "./session.js";
+import { restoreSession, saveSession } from "./session.js";
 import { extractAssistantTextFromTurn, extractErrorFromTurn } from "./response.js";
 import type { WorkerProgressEvent } from "./worker.js";
 import { relayTaskUpdateToTelegram, relayJobCompletionToTelegram } from "./telegram-notify.js";
@@ -64,6 +64,45 @@ const AGENT_CARD = {
     "ssh_to_nas",
   ],
 };
+
+async function registerAgentWeaveSession(ctx: SessionContext): Promise<void> {
+  if (!ctx.parentSessionId) return;
+  const AGENTWEAVE_PROXY_TOKEN = process.env.AGENTWEAVE_PROXY_TOKEN;
+  try {
+    await fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
+      },
+      body: JSON.stringify({
+        session_id: ctx.sessionId,
+        session_key: ctx.sessionKey,
+        parent_session_id: ctx.parentSessionId,
+        parent_session_key: ctx.parentSessionKey,
+        task_label: ctx.taskLabel || "a2a task",
+        agent_type: "delegated",
+      }),
+    });
+    log("info", `AgentWeave session set: ${ctx.sessionId} (parent: ${ctx.parentSessionId})`);
+  } catch (e: any) {
+    log("warn", `AgentWeave session set failed: ${e.message}`);
+  }
+}
+
+function messagesForTui(agent: Agent): { role: string; text: string }[] {
+  return agent.state.messages
+    .map((msg: any) => {
+      const text = Array.isArray(msg.content)
+        ? msg.content
+            .filter((c: any) => c.type === "text" && typeof c.text === "string")
+            .map((c: any) => c.text)
+            .join("")
+        : "";
+      return { role: msg.role, text };
+    })
+    .filter((msg) => (msg.role === "user" || msg.role === "assistant") && msg.text);
+}
 
 /**
  * Drain unreported activity entries to Telegram and advance the watermark.
@@ -114,14 +153,21 @@ export function createA2AServer(agent: Agent): express.Express {
     });
   });
 
+  app.get("/messages", authMiddleware, (_req, res) => {
+    const sessionContext = makeTuiSessionContext();
+    restoreSession(agent, sessionContext);
+    res.json({ sessionId: sessionContext.sessionId, sessionKey: sessionContext.sessionKey, messages: messagesForTui(agent) });
+  });
+
   app.post("/tasks", authMiddleware, async (req, res) => {
     let taskId: string | undefined;
 
     const parentSessionId = req.headers["x-agentweave-parent-session-id"] as string | undefined;
+    const parentSessionKey = req.headers["x-agentweave-parent-session-key"] as string | undefined;
     const delegatedSessionId = req.headers["x-agentweave-delegated-session-id"] as string | undefined;
+    const delegatedSessionKey = req.headers["x-agentweave-delegated-session-key"] as string | undefined;
     const callerAgentId = req.headers["x-agentweave-agent-id"] as string | undefined;
     const taskLabel = req.headers["x-agentweave-task-label"] as string | undefined;
-    const AGENTWEAVE_PROXY_TOKEN = process.env.AGENTWEAVE_PROXY_TOKEN;
 
     // Extract W3C traceparent from incoming request (for Nix → Max delegations).
     // Workers run in a separate thread — AsyncLocalStorage context doesn't cross
@@ -147,6 +193,16 @@ export function createA2AServer(agent: Agent): express.Express {
       const budgetCapUsd = isSync ? null : resolveBudgetCap(params.metadata);
       const task = createTask("a2a_task", "nix", { text, metadata: params.metadata }, { budgetCapUsd });
       taskId = task.id;
+      const sessionContext = makeA2ASessionContext({
+        taskId: task.id,
+        sync: isSync,
+        parentSessionId,
+        parentSessionKey,
+        delegatedSessionId,
+        delegatedSessionKey,
+        callerAgentId,
+        taskLabel,
+      });
       updateTaskStatus(task.id, "working");
 
       if (!isSync) {
@@ -161,9 +217,12 @@ export function createA2AServer(agent: Agent): express.Express {
               taskId: task.id,
               text,
               parentSessionId,
+              parentSessionKey,
               delegatedSessionId,
+              delegatedSessionKey,
               callerAgentId,
               taskLabel,
+              sessionContext,
               traceHeaders,
               maxBudgetUsd: budgetCapUsd,
             },
@@ -244,32 +303,12 @@ export function createA2AServer(agent: Agent): express.Express {
         return;
       }
 
-      if (parentSessionId) {
-        const sessionId = delegatedSessionId || `max-a2a-${task.id}`;
-        try {
-          await fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
-            },
-            body: JSON.stringify({
-              session_id: sessionId,
-              parent_session_id: parentSessionId,
-              task_label: taskLabel || `a2a from ${callerAgentId || "nix"}`,
-              agent_type: "delegated",
-            }),
-          });
-          log("info", `AgentWeave session set: ${sessionId} (parent: ${parentSessionId})`);
-          setAgentWeaveSession(sessionId);
-        } catch (e: any) {
-          log("warn", `AgentWeave session set failed: ${e.message}`);
-        }
-      }
+      await registerAgentWeaveSession(sessionContext);
 
       // Execute sync task within the incoming trace context as well
       const executeSyncTask = async () => {
         let responseText = "";
+        restoreSession(agent, sessionContext);
         const turnStartIndex = agent.state.messages.length;
         const unsub = agent.subscribe((event: AgentEvent) => {
           if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
@@ -288,7 +327,7 @@ export function createA2AServer(agent: Agent): express.Express {
           ? extractErrorFromTurn(agent.state.messages as any, turnStartIndex)
           : null;
 
-        saveSession(agent);
+        saveSession(agent, sessionContext);
 
         if (llmError) {
           log("warn", `LLM error during A2A sync task ${task.id}: ${llmError}`);
@@ -316,7 +355,7 @@ export function createA2AServer(agent: Agent): express.Express {
         }
       };
 
-      await context.with(incomingContext, executeSyncTask);
+      await context.with(incomingContext, () => withSessionContext(sessionContext, executeSyncTask));
     } catch (e: any) {
       agent.abort();
       log("error", `A2A task error: ${e.message}`);
@@ -327,22 +366,7 @@ export function createA2AServer(agent: Agent): express.Express {
         error: { code: -32000, message: e.message },
       });
     } finally {
-      if (parentSessionId && String(req.query.sync || "false").toLowerCase() === "true") {
-        resetAgentWeaveSession();
-        fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
-          },
-          body: JSON.stringify({
-            session_id: "max-main",
-            parent_session_id: "",
-            task_label: "",
-            agent_type: "main",
-          }),
-        }).catch(() => {});
-      }
+      // Session attribution is scoped with AsyncLocalStorage; no process-global reset needed.
     }
   });
 
@@ -361,6 +385,7 @@ export function createA2AServer(agent: Agent): express.Express {
 
       const text = params.message.parts[0].text;
       log("info", `A2A stream task: ${text.slice(0, 100)}`);
+      const sessionContext = makeTuiSessionContext();
 
       const task = createTask("a2a_stream", "tui", { text });
       updateTaskStatus(task.id, "working");
@@ -378,6 +403,8 @@ export function createA2AServer(agent: Agent): express.Express {
 
       sendEvent("task_start", { taskId: task.id });
 
+      await withSessionContext(sessionContext, async () => {
+      restoreSession(agent, sessionContext);
       const unsub = agent.subscribe((event: AgentEvent) => {
         switch (event.type) {
           case "message_update":
@@ -396,7 +423,8 @@ export function createA2AServer(agent: Agent): express.Express {
 
       await agent.prompt(text);
       unsub();
-      saveSession(agent);
+      saveSession(agent, sessionContext);
+      });
 
       updateTaskStatus(task.id, "completed", { response: "(streamed)" });
       sendEvent("task_end", { taskId: task.id, status: "completed" });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -20,6 +20,7 @@ import { transformContext } from "./context.js";
 import { traceTools } from "./tracing.js";
 import { restoreSession } from "./session.js";
 import { checkPermission } from "./permissions.js";
+import { getSessionContext, type SessionContext } from "./agentweave-context.js";
 
 /**
  * Core tools — always registered. Small, general-purpose surface the model
@@ -113,7 +114,7 @@ function createDefaultModel(defaultModel: string) {
   return model;
 }
 
-export async function createAgent(): Promise<Agent> {
+export async function createAgent(sessionContext: SessionContext = getSessionContext()): Promise<Agent> {
   const defaultModel = process.env.DEFAULT_MODEL || "gemini-2.5-pro";
   const muxEnabled = process.env.MUX_ENABLED === "true";
   const model = muxEnabled ? createMuxModel(defaultModel) : createDefaultModel(defaultModel);
@@ -126,20 +127,26 @@ export async function createAgent(): Promise<Agent> {
   // Only send AgentWeave proxy token for non-Mux paths to avoid colliding with Mux auth.
   const proxyToken = process.env.AGENTWEAVE_PROXY_TOKEN;
   const muxApiKey = process.env.MUX_API_KEY;
-  const agentWeaveStreamFn: typeof streamSimple = (m, ctx, opts) =>
-    streamSimple(m, ctx, {
+  const agentWeaveStreamFn: typeof streamSimple = (m, ctx, opts) => {
+    const activeSession = getSessionContext();
+    return streamSimple(m, ctx, {
       ...opts,
       headers: {
         ...opts?.headers,
         "X-AgentWeave-Agent-Id": "max-v1",
-        "X-AgentWeave-Agent-Type": "main",
-        "X-AgentWeave-Session-Id": "max-main",
+        "X-AgentWeave-Agent-Type": activeSession.agentType,
+        "X-AgentWeave-Session-Id": activeSession.sessionId,
+        "X-AgentWeave-Session-Key": activeSession.sessionKey,
+        ...(activeSession.parentSessionId ? { "X-AgentWeave-Parent-Session-Id": activeSession.parentSessionId } : {}),
+        ...(activeSession.parentSessionKey ? { "X-AgentWeave-Parent-Session-Key": activeSession.parentSessionKey } : {}),
+        ...(activeSession.taskLabel ? { "X-AgentWeave-Task-Label": activeSession.taskLabel } : {}),
         "X-AgentWeave-Project": "max",
         "X-Runtime": "agent-max",
         ...(muxEnabled && muxApiKey ? { Authorization: `Bearer ${muxApiKey}` } : {}),
         ...(!muxEnabled && proxyToken ? { "X-AgentWeave-Proxy-Token": proxyToken } : {}),
       },
     });
+  };
 
   const agent = new Agent({
     initialState: {
@@ -180,7 +187,7 @@ export async function createAgent(): Promise<Agent> {
   agent.state.tools = allTools;
 
   // Restore previous session messages
-  restoreSession(agent);
+  restoreSession(agent, sessionContext);
 
   return agent;
 }

--- a/src/agentweave-context.ts
+++ b/src/agentweave-context.ts
@@ -1,18 +1,106 @@
-/**
- * Shared AgentWeave session context.
- * Updated by a2a-server.ts when processing A2A tasks.
- * Read by nix-relay.ts when invoking delegate_to_nix.
- */
-let _currentSession = "max-main";
+import { AsyncLocalStorage } from "async_hooks";
 
-export function setAgentWeaveSession(sessionId: string): void {
-  _currentSession = sessionId;
+export interface SessionContext {
+  /** AgentWeave/Langfuse session id used for trace attribution. */
+  sessionId: string;
+  /** Stable Max-owned bucket id used for persisted Pi messages. */
+  sessionKey: string;
+  /** AgentWeave agent type for this turn. */
+  agentType: "main" | "delegated" | "worker" | "subagent";
+  /** Optional parent session id when this session is delegated by another agent. */
+  parentSessionId?: string;
+  /** Optional parent session storage key supplied by the caller. */
+  parentSessionKey?: string;
+  /** Human-readable task label for traces/session graph rows. */
+  taskLabel?: string;
+}
+
+export const MAIN_SESSION_CONTEXT: SessionContext = {
+  sessionId: "max-main",
+  sessionKey: "main",
+  agentType: "main",
+};
+
+const storage = new AsyncLocalStorage<SessionContext>();
+
+function cleanPart(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 160) || "unknown";
+}
+
+export function normalizeSessionContext(ctx?: Partial<SessionContext> | null): SessionContext {
+  const sessionId = cleanPart(ctx?.sessionId || MAIN_SESSION_CONTEXT.sessionId);
+  const sessionKey = cleanPart(ctx?.sessionKey || sessionId);
+  return {
+    sessionId,
+    sessionKey,
+    agentType: ctx?.agentType || MAIN_SESSION_CONTEXT.agentType,
+    parentSessionId: ctx?.parentSessionId ? cleanPart(ctx.parentSessionId) : undefined,
+    parentSessionKey: ctx?.parentSessionKey ? cleanPart(ctx.parentSessionKey) : undefined,
+    taskLabel: ctx?.taskLabel,
+  };
+}
+
+export function getSessionContext(): SessionContext {
+  return storage.getStore() ?? MAIN_SESSION_CONTEXT;
+}
+
+export function withSessionContext<T>(ctx: Partial<SessionContext>, fn: () => T): T {
+  return storage.run(normalizeSessionContext(ctx), fn);
+}
+
+export function makeTelegramSessionContext(chatId: string | number): SessionContext {
+  const chat = cleanPart(String(chatId));
+  return {
+    sessionId: `max-telegram-${chat}`,
+    sessionKey: `telegram:${chat}`,
+    agentType: "main",
+  };
+}
+
+export function makeA2ASessionContext(args: {
+  taskId: string;
+  sync: boolean;
+  parentSessionId?: string;
+  delegatedSessionId?: string;
+  delegatedSessionKey?: string;
+  callerAgentId?: string;
+  taskLabel?: string;
+  parentSessionKey?: string;
+}): SessionContext {
+  const caller = cleanPart(args.callerAgentId || "unknown");
+  const mode = args.sync ? "sync" : "worker";
+  const sessionId = args.delegatedSessionId || `max-a2a-${args.taskId}`;
+  return {
+    sessionId,
+    sessionKey: args.delegatedSessionKey ? cleanPart(args.delegatedSessionKey) : `a2a:${mode}:${caller}:${args.taskId}`,
+    agentType: args.sync ? "delegated" : "worker",
+    parentSessionId: args.parentSessionId,
+    parentSessionKey: args.parentSessionKey,
+    taskLabel: args.taskLabel,
+  };
+}
+
+export function makeTuiSessionContext(): SessionContext {
+  return {
+    sessionId: "max-tui",
+    sessionKey: "tui",
+    agentType: "main",
+  };
 }
 
 export function getAgentWeaveSession(): string {
-  return _currentSession;
+  return getSessionContext().sessionId;
 }
 
-export function resetAgentWeaveSession(): void {
-  _currentSession = "max-main";
+export function getAgentWeaveSessionKey(): string {
+  return getSessionContext().sessionKey;
 }
+
+// Backwards-compatible shims for older tests/imports. New runtime code should
+// use withSessionContext() so async work cannot inherit stale process globals.
+export function setAgentWeaveSession(_sessionId: string): void {}
+export function resetAgentWeaveSession(): void {}

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,11 +2,24 @@ import type { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { getState, setState } from "./task-journal.js";
 import { log } from "./logger.js";
+import { getSessionContext, MAIN_SESSION_CONTEXT, type SessionContext } from "./agentweave-context.js";
 
-const SESSION_KEY = "session_messages";
+const LEGACY_SESSION_KEY = "session_messages";
+const SESSION_KEY_PREFIX = "session_messages:";
 const MAX_TOOL_RESULT_CHARS = 2000; // truncate tool results to prevent session bloat
 const MAX_SESSION_MESSAGES = 20; // only save the most recent messages
-let saveTimer: ReturnType<typeof setTimeout> | null = null;
+const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function contextOrActive(ctx?: SessionContext): SessionContext {
+  return ctx ?? getSessionContext();
+}
+
+export function storageKeyForSession(ctxOrKey?: SessionContext | string): string {
+  const sessionKey = typeof ctxOrKey === "string"
+    ? ctxOrKey
+    : contextOrActive(ctxOrKey).sessionKey;
+  return `${SESSION_KEY_PREFIX}${sessionKey}`;
+}
 
 /**
  * Truncate large tool results, strip thinking blocks, and limit message count
@@ -53,19 +66,26 @@ function trimForStorage(messages: AgentMessage[]): AgentMessage[] {
 /**
  * Save agent messages to SQLite (debounced 500ms).
  */
-export function saveSession(agent: Agent): void {
-  if (saveTimer) clearTimeout(saveTimer);
-  saveTimer = setTimeout(() => {
+export function saveSession(agent: Agent, ctx?: SessionContext): void {
+  const sessionContext = contextOrActive(ctx);
+  const stateKey = storageKeyForSession(sessionContext);
+  const messages = [...agent.state.messages];
+  const existingTimer = saveTimers.get(stateKey);
+  if (existingTimer) clearTimeout(existingTimer);
+  const timer = setTimeout(() => {
     try {
-      const { messages: repaired } = repairErroredAssistantTurns(agent.state.messages);
+      const { messages: repaired } = repairErroredAssistantTurns(messages);
       const trimmed = trimForStorage(repaired);
       const json = JSON.stringify(trimmed);
-      setState(SESSION_KEY, json);
-      log("info", `Session saved (${trimmed.length} of ${agent.state.messages.length} messages)`);
+      setState(stateKey, json);
+      log("info", `Session saved for ${sessionContext.sessionKey} (${trimmed.length} of ${messages.length} messages)`);
     } catch (e: any) {
-      log("error", `Failed to save session: ${e.message}`);
+      log("error", `Failed to save session ${sessionContext.sessionKey}: ${e.message}`);
+    } finally {
+      saveTimers.delete(stateKey);
     }
   }, 500);
+  saveTimers.set(stateKey, timer);
 }
 
 /**
@@ -97,24 +117,35 @@ function repairErroredAssistantTurns(messages: AgentMessage[]): { messages: Agen
  * Restore agent messages from SQLite.
  * Returns the number of messages restored.
  */
-export function restoreSession(agent: Agent): number {
+export function restoreSession(agent: Agent, ctx?: SessionContext): number {
+  const sessionContext = contextOrActive(ctx);
+  const stateKey = storageKeyForSession(sessionContext);
   try {
-    const json = getState(SESSION_KEY);
-    if (!json) return 0;
+    let json = getState(stateKey);
+    if (!json && sessionContext.sessionKey === MAIN_SESSION_CONTEXT.sessionKey) {
+      json = getState(LEGACY_SESSION_KEY);
+    }
+    if (!json) {
+      agent.state.messages = [];
+      return 0;
+    }
 
     const parsed = JSON.parse(json);
-    if (!Array.isArray(parsed) || parsed.length === 0) return 0;
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      agent.state.messages = [];
+      return 0;
+    }
 
     const { messages, repaired } = repairErroredAssistantTurns(parsed);
     agent.state.messages = messages;
     if (repaired > 0) {
-      log("info", `Session restored (${messages.length} messages, repaired ${repaired} errored assistant turns)`);
+      log("info", `Session restored for ${sessionContext.sessionKey} (${messages.length} messages, repaired ${repaired} errored assistant turns)`);
     } else {
-      log("info", `Session restored (${messages.length} messages)`);
+      log("info", `Session restored for ${sessionContext.sessionKey} (${messages.length} messages)`);
     }
     return messages.length;
   } catch (e: any) {
-    log("error", `Failed to restore session: ${e.message}`);
+    log("error", `Failed to restore session ${sessionContext.sessionKey}: ${e.message}`);
     return 0;
   }
 }
@@ -122,11 +153,15 @@ export function restoreSession(agent: Agent): number {
 /**
  * Clear saved session from SQLite.
  */
-export function clearSession(): void {
+export function clearSession(ctx?: SessionContext): void {
+  const sessionContext = contextOrActive(ctx);
   try {
-    setState(SESSION_KEY, "[]");
-    log("info", "Session cleared");
+    setState(storageKeyForSession(sessionContext), "[]");
+    if (sessionContext.sessionKey === MAIN_SESSION_CONTEXT.sessionKey) {
+      setState(LEGACY_SESSION_KEY, "[]");
+    }
+    log("info", `Session cleared for ${sessionContext.sessionKey}`);
   } catch (e: any) {
-    log("error", `Failed to clear session: ${e.message}`);
+    log("error", `Failed to clear session ${sessionContext.sessionKey}: ${e.message}`);
   }
 }

--- a/src/telegram-bot.ts
+++ b/src/telegram-bot.ts
@@ -5,8 +5,9 @@ import { writeMemoryEvent } from "./memory.js";
 import { createTask, updateTaskStatus, getRecentTasks } from "./task-journal.js";
 import { log } from "./logger.js";
 import { traceAgentTurn } from "./tracing.js";
-import { saveSession, clearSession } from "./session.js";
+import { restoreSession, saveSession, clearSession } from "./session.js";
 import { extractAssistantTextFromTurn, extractErrorFromTurn } from "./response.js";
+import { makeTelegramSessionContext, withSessionContext } from "./agentweave-context.js";
 
 // ── Deduplication — Issue #2 ─────────────────────────────────────────────────
 const processedUpdateIds = new Set<number>();
@@ -249,7 +250,7 @@ export function createTelegramBot(agent: Agent): Bot {
     if (!isAllowed(ctx)) return;
     conversationHistory.length = 0;
     agent.clearMessages();
-    clearSession();
+    clearSession(makeTelegramSessionContext(ctx.chat.id));
     await ctx.reply("Conversation context cleared.");
   });
 
@@ -487,8 +488,9 @@ export function createTelegramBot(agent: Agent): Bot {
         }
       });
 
-      const turnStartIndex = agent.state.messages.length;
+      restoreSession(agent);
       startEditing();
+      const restoredTurnStartIndex = agent.state.messages.length;
       await agent.prompt(text, images);
       unsub();
 
@@ -497,11 +499,11 @@ export function createTelegramBot(agent: Agent): Bot {
       if (pendingStatusEdit) clearTimeout(pendingStatusEdit);
 
       if (!responseText) {
-        responseText = extractAssistantTextFromTurn(agent.state.messages as any, turnStartIndex);
+        responseText = extractAssistantTextFromTurn(agent.state.messages as any, restoredTurnStartIndex);
       }
 
       if (!responseText) {
-        const llmError = extractErrorFromTurn(agent.state.messages as any, turnStartIndex);
+        const llmError = extractErrorFromTurn(agent.state.messages as any, restoredTurnStartIndex);
         if (llmError) {
           log("warn", `LLM error during prompt: ${llmError}`);
           updateTaskStatus(task.id, "failed", { error: llmError });
@@ -601,12 +603,12 @@ export function createTelegramBot(agent: Agent): Bot {
       log("warn", `Duplicate update ${updateId} ignored`);
       return;
     }
-    const sessionId = `tg-${ctx.chat.id}`;
+    const sessionContext = makeTelegramSessionContext(ctx.chat.id);
     const telegramMessageId = ctx.message.message_id;
     const chatId = ctx.chat.id;
     await traceAgentTurn("handleMessage", async () => {
-      await handleMessage(ctx, ctx.message.text);
-    }, { sessionId, telegramMessageId, chatId });
+      await withSessionContext(sessionContext, () => handleMessage(ctx, ctx.message.text));
+    }, { sessionId: sessionContext.sessionId, sessionKey: sessionContext.sessionKey, telegramMessageId, chatId });
   });
 
   // Photo messages (with optional caption)
@@ -619,7 +621,7 @@ export function createTelegramBot(agent: Agent): Bot {
     }
 
     const caption = ctx.message.caption || "What do you see in this image?";
-    const sessionId = `tg-${ctx.chat.id}`;
+    const sessionContext = makeTelegramSessionContext(ctx.chat.id);
     const telegramMessageId = ctx.message.message_id;
     const chatId = ctx.chat.id;
 
@@ -641,8 +643,8 @@ export function createTelegramBot(agent: Agent): Bot {
       const mimeType = ext === "png" ? "image/png" : ext === "gif" ? "image/gif" : ext === "webp" ? "image/webp" : "image/jpeg";
 
       await traceAgentTurn("handleMessage", async () => {
-        await handleMessage(ctx, caption, [{ type: "image", data: base64, mimeType }]);
-      }, { sessionId, telegramMessageId, chatId });
+        await withSessionContext(sessionContext, () => handleMessage(ctx, caption, [{ type: "image", data: base64, mimeType }]));
+      }, { sessionId: sessionContext.sessionId, sessionKey: sessionContext.sessionKey, telegramMessageId, chatId });
     } catch (e: any) {
       log("error", `Failed to process photo: ${e.message}`);
       await ctx.reply(`Failed to process image: ${e.message}`);

--- a/src/tools/claude-subagent.ts
+++ b/src/tools/claude-subagent.ts
@@ -4,7 +4,7 @@ import { spawn, ChildProcess } from "child_process";
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { log } from "../logger.js";
-import { getAgentWeaveSession } from "../agentweave-context.js";
+import { getAgentWeaveSession, getAgentWeaveSessionKey } from "../agentweave-context.js";
 import { relayJobCompletionToTelegram } from "../telegram-notify.js";
 import { headAndTail } from "./truncate.js";
 
@@ -143,12 +143,14 @@ function startClaudeDelegation(prompt: string, taskLabel?: string, silent?: bool
 
   const jobId = crypto.randomUUID();
   const parentSessionId = getAgentWeaveSession();
+  const parentSessionKey = getAgentWeaveSessionKey();
   const childSessionId = `max-claude-subagent-${jobId}`;
   const label = taskLabel?.trim() || `claude_subagent:${prompt.slice(0, 60)}`;
 
   const attributionHeaders: Record<string, string> = {
     "X-AgentWeave-Session-Id": childSessionId,
     "X-AgentWeave-Parent-Session-Id": parentSessionId,
+    "X-AgentWeave-Parent-Session-Key": parentSessionKey,
     "X-AgentWeave-Agent-Id": process.env.AGENTWEAVE_AGENT_ID || "max-v1",
     "X-AgentWeave-Agent-Type": "subagent",
     "X-AgentWeave-Task-Label": label,
@@ -165,6 +167,7 @@ function startClaudeDelegation(prompt: string, taskLabel?: string, silent?: bool
     ANTHROPIC_CUSTOM_HEADERS: makeCustomHeaders(attributionHeaders),
     AGENTWEAVE_SESSION_ID: childSessionId,
     AGENTWEAVE_PARENT_SESSION_ID: parentSessionId,
+    AGENTWEAVE_PARENT_SESSION_KEY: parentSessionKey,
     AGENTWEAVE_AGENT_ID: process.env.AGENTWEAVE_AGENT_ID || "max-v1",
     AGENTWEAVE_AGENT_TYPE: "subagent",
     AGENTWEAVE_TASK_LABEL: label,

--- a/src/tools/nix-relay.ts
+++ b/src/tools/nix-relay.ts
@@ -2,7 +2,7 @@ import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { context, propagation } from "@opentelemetry/api";
 import { log } from "../logger.js";
-import { getAgentWeaveSession } from "../agentweave-context.js";
+import { getAgentWeaveSession, getAgentWeaveSessionKey } from "../agentweave-context.js";
 
 const NIX_A2A_URL = process.env.NIX_A2A_URL || "http://localhost:8771";
 const A2A_SHARED_SECRET = process.env.A2A_SHARED_SECRET || "";
@@ -33,7 +33,9 @@ export const delegateToNix: AgentTool = {
           ...(() => { const h: Record<string, string> = {}; propagation.inject(context.active(), h); return h; })(),
           // AgentWeave session attribution for trace propagation
           "X-AgentWeave-Parent-Session-Id": getAgentWeaveSession(),
+          "X-AgentWeave-Parent-Session-Key": getAgentWeaveSessionKey(),
           "X-AgentWeave-Delegated-Session-Id": `nix-a2a-${taskId}`,
+          "X-AgentWeave-Delegated-Session-Key": `nix:a2a:${taskId}`,
           "X-AgentWeave-Agent-Id": process.env.AGENTWEAVE_AGENT_ID || "max-v1",
           "X-AgentWeave-Task-Label": `a2a:${skill_id || "general"}:${task.slice(0, 50)}`,
         },

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -2,10 +2,13 @@ import { AgentWeaveConfig, traceTool, withSpan } from "agentweave";
 import {
   PROV_ACTIVITY_TYPE, ACTIVITY_AGENT_TURN,
   PROV_AGENT_ID, PROV_WAS_ASSOCIATED_WITH,
-  PROV_AGENT_TYPE, AGENT_TYPE_MAIN,
 } from "agentweave";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { log } from "./logger.js";
+import { getSessionContext } from "./agentweave-context.js";
+
+const PROV_AGENT_TYPE = "prov.agent.type";
+const AGENT_TYPE_MAIN = "main";
 
 /**
  * Initialize AgentWeave tracing. Call once at startup before agent creation.
@@ -55,15 +58,20 @@ export function traceTools(tools: AgentTool[]): AgentTool[] {
 export function traceAgentTurn<T>(
   name: string,
   fn: () => T | Promise<T>,
-  meta?: { sessionId?: string; telegramMessageId?: number; chatId?: number }
+  meta?: { sessionId?: string; sessionKey?: string; telegramMessageId?: number; chatId?: number }
 ): T | Promise<T> {
   if (!AgentWeaveConfig.enabled) return fn();
+  const activeSession = getSessionContext();
+  const sessionId = meta?.sessionId || activeSession.sessionId;
+  const sessionKey = meta?.sessionKey || activeSession.sessionKey;
   return withSpan(`agent.${name}`, {
     [PROV_ACTIVITY_TYPE]: ACTIVITY_AGENT_TURN,
     [PROV_AGENT_ID]: "max-v1",
     [PROV_WAS_ASSOCIATED_WITH]: "max-v1",
-    [PROV_AGENT_TYPE]: AGENT_TYPE_MAIN,
-    ...(meta?.sessionId ? { 'session.id': meta.sessionId, 'prov.session.id': meta.sessionId } : {}),
+    [PROV_AGENT_TYPE]: activeSession.agentType || AGENT_TYPE_MAIN,
+    'session.id': sessionId,
+    'prov.session.id': sessionId,
+    'prov.session.key': sessionKey,
     ...(meta?.telegramMessageId ? { 'telegram.message_id': String(meta.telegramMessageId) } : {}),
     ...(meta?.chatId ? { 'telegram.chat_id': String(meta.chatId) } : {}),
   }, () => fn());

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,7 +2,7 @@ import { parentPort, workerData } from "worker_threads";
 import { context, propagation } from "@opentelemetry/api";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { createAgent } from "./agent.js";
-import { setAgentWeaveSession, resetAgentWeaveSession } from "./agentweave-context.js";
+import { makeA2ASessionContext, withSessionContext, type SessionContext } from "./agentweave-context.js";
 import { log } from "./logger.js";
 import { saveSession } from "./session.js";
 import { emitSessionArtifact, inferProjectsFromText } from "./session-emit.js";
@@ -25,9 +25,12 @@ interface WorkerTaskData {
   taskId: string;
   text: string;
   parentSessionId?: string;
+  parentSessionKey?: string;
   delegatedSessionId?: string;
+  delegatedSessionKey?: string;
   callerAgentId?: string;
   taskLabel?: string;
+  sessionContext?: SessionContext;
   /** Serialized W3C trace headers (e.g. traceparent) from the calling agent. */
   traceHeaders?: Record<string, string>;
   /** Per-task USD spend cap. When exceeded, the agent is aborted. */
@@ -50,7 +53,7 @@ async function postProgress(event: WorkerProgressEvent): Promise<void> {
 }
 
 async function main() {
-  const { taskId, text, parentSessionId, delegatedSessionId, callerAgentId, taskLabel, traceHeaders, maxBudgetUsd } = workerData as WorkerTaskData;
+  const { taskId, text, parentSessionId, parentSessionKey, delegatedSessionId, delegatedSessionKey, callerAgentId, taskLabel, traceHeaders, maxBudgetUsd } = workerData as WorkerTaskData;
 
   // Re-extract trace context from serialized headers so this worker's spans
   // are linked as children of the calling agent's trace.
@@ -65,8 +68,19 @@ async function main() {
   try {
     await postProgress({ type: "progress", taskId, message: "Worker started" });
 
-    if (parentSessionId) {
-      const sessionId = delegatedSessionId || `max-a2a-${taskId}`;
+    const sessionContext = (workerData as WorkerTaskData).sessionContext ?? makeA2ASessionContext({
+      taskId,
+      sync: false,
+      parentSessionId,
+      parentSessionKey,
+      delegatedSessionId,
+      delegatedSessionKey,
+      callerAgentId,
+      taskLabel,
+    });
+
+    await withSessionContext(sessionContext, async () => {
+    if (sessionContext.parentSessionId) {
       try {
         await fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
           method: "POST",
@@ -75,19 +89,20 @@ async function main() {
             ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
           },
           body: JSON.stringify({
-            session_id: sessionId,
-            parent_session_id: parentSessionId,
-            task_label: taskLabel || `a2a from ${callerAgentId || "nix"}`,
+            session_id: sessionContext.sessionId,
+            session_key: sessionContext.sessionKey,
+            parent_session_id: sessionContext.parentSessionId,
+            parent_session_key: sessionContext.parentSessionKey,
+            task_label: sessionContext.taskLabel || taskLabel || `a2a from ${callerAgentId || "nix"}`,
             agent_type: "delegated",
           }),
         });
-        setAgentWeaveSession(sessionId);
       } catch (e: any) {
         log("warn", `Worker AgentWeave session set failed: ${e.message}`);
       }
     }
 
-    const agent = await createAgent();
+    const agent = await createAgent(sessionContext);
     let responseText = "";
     let budgetExceeded = false;
 
@@ -120,7 +135,7 @@ async function main() {
     unsub();
 
     if (budgetExceeded) {
-      saveSession(agent);
+      saveSession(agent, sessionContext);
       emitSessionArtifact({
         topic: taskLabel || text.slice(0, 80),
         projects: inferProjectsFromText(text),
@@ -151,7 +166,7 @@ async function main() {
     if (!responseText) {
       const lastMsg: any = agent.state.messages[agent.state.messages.length - 1];
       if (lastMsg?.role === "assistant" && lastMsg.stopReason === "error" && lastMsg.errorMessage) {
-        saveSession(agent);
+        saveSession(agent, sessionContext);
         emitSessionArtifact({
           topic: taskLabel || text.slice(0, 80),
           projects: inferProjectsFromText(text),
@@ -167,7 +182,7 @@ async function main() {
       }
     }
 
-    saveSession(agent);
+    saveSession(agent, sessionContext);
     emitSessionArtifact({
       topic: taskLabel || text.slice(0, 80),
       projects: inferProjectsFromText(text),
@@ -179,6 +194,7 @@ async function main() {
       message: "Worker completed",
       result: responseText,
       costUsd: cumulativeCostUsd,
+    });
     });
   } catch (e: any) {
     emitSessionArtifact({
@@ -193,23 +209,7 @@ async function main() {
       costUsd: cumulativeCostUsd,
     });
   } finally {
-    if (parentSessionId) {
-      resetAgentWeaveSession();
-      const AGENTWEAVE_PROXY_TOKEN = process.env.AGENTWEAVE_PROXY_TOKEN;
-      fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
-        },
-        body: JSON.stringify({
-          session_id: "max-main",
-          parent_session_id: "",
-          task_label: "",
-          agent_type: "main",
-        }),
-      }).catch(() => {});
-    }
+    // Session attribution is scoped with AsyncLocalStorage; no process-global reset needed.
   }
   }); // end context.with
 }

--- a/tests/a2a-callback.test.ts
+++ b/tests/a2a-callback.test.ts
@@ -24,12 +24,23 @@ jest.unstable_mockModule("../src/task-journal.js", () => ({
 jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
 jest.unstable_mockModule("../src/session.js", () => ({
   saveSession: jest.fn(),
+  restoreSession: jest.fn(),
   loadSession: jest.fn().mockReturnValue(null),
 }));
 jest.unstable_mockModule("../src/agentweave-context.js", () => ({
   setAgentWeaveSession: jest.fn(),
   resetAgentWeaveSession: jest.fn(),
   getAgentWeaveSession: jest.fn().mockReturnValue("max-main"),
+  makeA2ASessionContext: jest.fn((args: any) => ({
+    sessionId: args.delegatedSessionId || `max-a2a-${args.taskId}`,
+    sessionKey: `a2a:${args.sync ? "sync" : "worker"}:test:${args.taskId}`,
+    agentType: args.sync ? "delegated" : "worker",
+    parentSessionId: args.parentSessionId,
+    parentSessionKey: args.parentSessionKey,
+    taskLabel: args.taskLabel,
+  })),
+  makeTuiSessionContext: jest.fn(() => ({ sessionId: "max-tui", sessionKey: "tui", agentType: "main" })),
+  withSessionContext: jest.fn((_ctx: any, fn: any) => fn()),
 }));
 jest.unstable_mockModule("../src/response.js", () => ({
   extractAssistantTextFromTurn: jest.fn().mockReturnValue(""),

--- a/tests/a2a-trace-propagation.test.ts
+++ b/tests/a2a-trace-propagation.test.ts
@@ -33,12 +33,23 @@ jest.unstable_mockModule("../src/task-journal.js", () => ({
 jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
 jest.unstable_mockModule("../src/session.js", () => ({
   saveSession: jest.fn(),
+  restoreSession: jest.fn(),
   loadSession: jest.fn().mockReturnValue(null),
 }));
 jest.unstable_mockModule("../src/agentweave-context.js", () => ({
   setAgentWeaveSession: jest.fn(),
   resetAgentWeaveSession: jest.fn(),
   getAgentWeaveSession: jest.fn().mockReturnValue("max-main"),
+  makeA2ASessionContext: jest.fn((args: any) => ({
+    sessionId: args.delegatedSessionId || `max-a2a-${args.taskId}`,
+    sessionKey: `a2a:${args.sync ? "sync" : "worker"}:test:${args.taskId}`,
+    agentType: args.sync ? "delegated" : "worker",
+    parentSessionId: args.parentSessionId,
+    parentSessionKey: args.parentSessionKey,
+    taskLabel: args.taskLabel,
+  })),
+  makeTuiSessionContext: jest.fn(() => ({ sessionId: "max-tui", sessionKey: "tui", agentType: "main" })),
+  withSessionContext: jest.fn((_ctx: any, fn: any) => fn()),
 }));
 jest.unstable_mockModule("../src/response.js", () => ({
   extractAssistantTextFromTurn: jest.fn().mockReturnValue(""),

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { webcrypto } from "crypto";
+
+jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
+
+const { withSessionContext, getAgentWeaveSession, getAgentWeaveSessionKey } = await import("../src/agentweave-context.js");
+const { delegateToNix } = await import("../src/tools/nix-relay.js");
+
+beforeEach(() => {
+  delete process.env.A2A_SHARED_SECRET;
+  (globalThis as any).crypto = webcrypto;
+});
+
+describe("active session context", () => {
+  it("keeps concurrent async session ids isolated", async () => {
+    const [a, b] = await Promise.all([
+      withSessionContext({ sessionId: "session-a", sessionKey: "bucket-a", agentType: "main" }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return [getAgentWeaveSession(), getAgentWeaveSessionKey()];
+      }),
+      withSessionContext({ sessionId: "session-b", sessionKey: "bucket-b", agentType: "delegated" }, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        return [getAgentWeaveSession(), getAgentWeaveSessionKey()];
+      }),
+    ]);
+
+    expect(a).toEqual(["session-a", "bucket-a"]);
+    expect(b).toEqual(["session-b", "bucket-b"]);
+    expect(getAgentWeaveSession()).toBe("max-main");
+  });
+
+  it("delegate_to_nix propagates active session id and key headers", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "nix-task-1", status: "completed", result: { reply: "done" } }),
+    } as any);
+    const previousFetch = global.fetch;
+    global.fetch = fetchMock;
+
+    try {
+      await withSessionContext(
+        { sessionId: "max-telegram-42", sessionKey: "telegram:42", agentType: "main" },
+        () => delegateToNix.execute("tool-1", { task: "hello", skill_id: "general" } as any)
+      );
+
+      const headers = fetchMock.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["X-AgentWeave-Parent-Session-Id"]).toBe("max-telegram-42");
+      expect(headers["X-AgentWeave-Parent-Session-Key"]).toBe("telegram:42");
+      expect(headers["X-AgentWeave-Delegated-Session-Id"]).toMatch(/^nix-a2a-/);
+      expect(headers["X-AgentWeave-Delegated-Session-Key"]).toMatch(/^nix:a2a:/);
+    } finally {
+      global.fetch = previousFetch;
+    }
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+
+const state = new Map<string, string>();
+
+jest.unstable_mockModule("../src/task-journal.js", () => ({
+  getState: jest.fn((key: string) => state.get(key)),
+  setState: jest.fn((key: string, value: string) => state.set(key, value)),
+}));
+
+jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
+
+function makeAgent(messages: any[] = []) {
+  return { state: { messages } } as any;
+}
+
+function user(text: string) {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+beforeEach(async () => {
+  jest.useFakeTimers();
+  state.clear();
+});
+
+afterEach(async () => {
+  jest.useRealTimers();
+  state.clear();
+});
+
+describe("session storage isolation", () => {
+  it("saves and restores messages by explicit sessionKey", async () => {
+    const { saveSession, restoreSession } = await import("../src/session.js");
+
+    const telegramCtx = { sessionId: "max-telegram-1", sessionKey: "telegram:1", agentType: "main" as const };
+    const a2aCtx = { sessionId: "max-a2a-task-1", sessionKey: "a2a:sync:nix:task-1", agentType: "delegated" as const };
+
+    saveSession(makeAgent([user("telegram turn")]), telegramCtx);
+    saveSession(makeAgent([user("a2a turn")]), a2aCtx);
+    jest.advanceTimersByTime(600);
+
+    const restoredTelegram = makeAgent([user("contaminated")]);
+    const restoredA2A = makeAgent([user("contaminated")]);
+
+    expect(restoreSession(restoredTelegram, telegramCtx)).toBe(1);
+    expect(restoreSession(restoredA2A, a2aCtx)).toBe(1);
+    expect((restoredTelegram.state.messages[0] as any).content[0].text).toBe("telegram turn");
+    expect((restoredA2A.state.messages[0] as any).content[0].text).toBe("a2a turn");
+  });
+
+  it("clears in-memory messages when switching to an empty bucket", async () => {
+    const { restoreSession } = await import("../src/session.js");
+    const emptyCtx = { sessionId: "max-telegram-2", sessionKey: "telegram:2", agentType: "main" as const };
+    const agent = makeAgent([user("previous bucket")]);
+
+    expect(restoreSession(agent, emptyCtx)).toBe(0);
+    expect(agent.state.messages).toEqual([]);
+  });
+
+  it("snapshots messages at save time so later bucket switches cannot contaminate debounced saves", async () => {
+    const { saveSession, restoreSession } = await import("../src/session.js");
+    const telegramCtx = { sessionId: "max-telegram-1", sessionKey: "telegram:1", agentType: "main" as const };
+    const a2aCtx = { sessionId: "max-a2a-task-1", sessionKey: "a2a:sync:nix:task-1", agentType: "delegated" as const };
+    const sharedAgent = makeAgent([user("telegram before timer")]);
+
+    saveSession(sharedAgent, telegramCtx);
+    sharedAgent.state.messages = [user("a2a after switch")];
+    saveSession(sharedAgent, a2aCtx);
+    jest.advanceTimersByTime(600);
+
+    const restoredTelegram = makeAgent();
+    const restoredA2A = makeAgent();
+    restoreSession(restoredTelegram, telegramCtx);
+    restoreSession(restoredA2A, a2aCtx);
+
+    expect((restoredTelegram.state.messages[0] as any).content[0].text).toBe("telegram before timer");
+    expect((restoredA2A.state.messages[0] as any).content[0].text).toBe("a2a after switch");
+  });
+
+  it("falls back to the legacy global key only for main session migration", async () => {
+    const { restoreSession } = await import("../src/session.js");
+
+    state.set("session_messages", JSON.stringify([user("legacy main")]));
+
+    const mainAgent = makeAgent();
+    const telegramAgent = makeAgent([user("previous")]);
+    expect(restoreSession(mainAgent, { sessionId: "max-main", sessionKey: "main", agentType: "main" })).toBe(1);
+    expect((mainAgent.state.messages[0] as any).content[0].text).toBe("legacy main");
+
+    expect(restoreSession(telegramAgent, { sessionId: "max-telegram-3", sessionKey: "telegram:3", agentType: "main" })).toBe(0);
+    expect(telegramAgent.state.messages).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Max-owned `SessionContext` routing with explicit `sessionId` and `sessionKey`.
- Store Pi Agent messages in per-session SQLite buckets, with legacy `session_messages` fallback only for the main session.
- Route Telegram chats, sync A2A, async A2A workers, and TUI stream/history through separate session contexts.
- Derive AgentWeave/Langfuse headers and delegate_to_nix propagation from the active session context instead of `max-main` globals.
- Add regression tests for storage isolation, debounced save snapshots, async context isolation, and delegation headers.

## Validation
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js tests/session.test.ts tests/session-context.test.ts tests/a2a-trace-propagation.test.ts tests/a2a-callback.test.ts --runInBand --forceExit` on NAS: 23 passed
- `npm run build` on Mac temp clone: passed
- `npm test -- --runInBand --forceExit` on Mac temp clone: 103 passed

Note: full NAS test/build is blocked by the local NAS toolchain: `better-sqlite3` was compiled for a different Node ABI and `npm` is not installed there.

Fixes arniesaha/agent-max#45
Fixes arniesaha/agent-max#46
