### PR TITLE
feat: add session-aware context briefs

### DIFF
--- a/src/a2a-server.ts
+++ b/src/a2a-server.ts
@@ -244,8 +244,10 @@ export function createA2AServer(agent: Agent): express.Express {
         return;
       }
 
+      let activeSessionKey = "max-main";
       if (parentSessionId) {
         const sessionId = delegatedSessionId || `max-a2a-${task.id}`;
+        activeSessionKey = sessionId;
         try {
           await fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
             method: "POST",
@@ -262,6 +264,7 @@ export function createA2AServer(agent: Agent): express.Express {
           });
           log("info", `AgentWeave session set: ${sessionId} (parent: ${parentSessionId})`);
           setAgentWeaveSession(sessionId);
+          agent.sessionId = sessionId;
         } catch (e: any) {
           log("warn", `AgentWeave session set failed: ${e.message}`);
         }
@@ -288,7 +291,7 @@ export function createA2AServer(agent: Agent): express.Express {
           ? extractErrorFromTurn(agent.state.messages as any, turnStartIndex)
           : null;
 
-        saveSession(agent);
+        saveSession(agent, { sessionKey: activeSessionKey });
 
         if (llmError) {
           log("warn", `LLM error during A2A sync task ${task.id}: ${llmError}`);
@@ -396,7 +399,7 @@ export function createA2AServer(agent: Agent): express.Express {
 
       await agent.prompt(text);
       unsub();
-      saveSession(agent);
+      saveSession(agent, { sessionKey: agent.sessionId || "max-main" });
 
       updateTaskStatus(task.id, "completed", { response: "(streamed)" });
       sendEvent("task_end", { taskId: task.id, status: "completed" });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -20,6 +20,7 @@ import { transformContext } from "./context.js";
 import { traceTools } from "./tracing.js";
 import { restoreSession } from "./session.js";
 import { checkPermission } from "./permissions.js";
+import { getAgentWeaveSession } from "./agentweave-context.js";
 
 /**
  * Core tools — always registered. Small, general-purpose surface the model
@@ -141,7 +142,8 @@ export async function createAgent(): Promise<Agent> {
       },
     });
 
-  const agent = new Agent({
+  let agent: Agent;
+  agent = new Agent({
     initialState: {
       systemPrompt,
       model,
@@ -155,7 +157,7 @@ export async function createAgent(): Promise<Agent> {
       }
       return getEnvApiKey(provider);
     },
-    transformContext,
+    transformContext: (messages) => transformContext(messages, agent.sessionId || getAgentWeaveSession()),
     streamFn: agentWeaveStreamFn,
   });
 
@@ -180,7 +182,8 @@ export async function createAgent(): Promise<Agent> {
   agent.state.tools = allTools;
 
   // Restore previous session messages
-  restoreSession(agent);
+  agent.sessionId = getAgentWeaveSession();
+  restoreSession(agent, { sessionKey: agent.sessionId });
 
   return agent;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,9 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, Message } from "@mariozechner/pi-ai";
 import { getModel, getEnvApiKey, streamSimple } from "@mariozechner/pi-ai";
 import { log } from "./logger.js";
+import { getAgentWeaveSession } from "./agentweave-context.js";
+import { getSessionBrief } from "./session.js";
+import { traceContextEvent } from "./tracing.js";
 
 /**
  * Context-sizing knobs.
@@ -41,6 +44,7 @@ function logConfigOnce(): void {
 // otherwise re-bills itself on every subsequent agent iteration.
 const FRESH_TURNS = Math.floor(Number(process.env.MAX_FRESH_TURNS || 4));
 const STALE_STUB_CHARS = 200; // keep a tiny prefix for continuity
+const CONTEXT_NOTE_MAX_CHARS = 8_000;
 
 /** Rough token estimate: ~4 chars per token for text, actual usage for assistant messages */
 function estimateMessageTokens(msg: AgentMessage): number {
@@ -83,12 +87,30 @@ export interface ContextStats {
   contextWindow: number;
   compactThreshold: number;
   usagePercent: number;
+  pruningCount: number;
+  compactionCount: number;
   compactions: number;
+  sessionKey?: string;
 }
 
-let compactionCount = 0;
+const sessionCounters = new Map<string, { pruningCount: number; compactionCount: number }>();
 
-export function getContextStats(messages: AgentMessage[]): ContextStats {
+function normalizeSessionKey(sessionKey?: string): string {
+  return sessionKey || getAgentWeaveSession() || "max-main";
+}
+
+function getCounters(sessionKey: string): { pruningCount: number; compactionCount: number } {
+  let counters = sessionCounters.get(sessionKey);
+  if (!counters) {
+    counters = { pruningCount: 0, compactionCount: 0 };
+    sessionCounters.set(sessionKey, counters);
+  }
+  return counters;
+}
+
+export function getContextStats(messages: AgentMessage[], sessionKey?: string): ContextStats {
+  const key = normalizeSessionKey(sessionKey);
+  const counters = getCounters(key);
   const totalTokens = messages.reduce((sum, m) => sum + estimateMessageTokens(m), 0);
   return {
     totalTokens,
@@ -96,8 +118,83 @@ export function getContextStats(messages: AgentMessage[]): ContextStats {
     contextWindow: CONTEXT_WINDOW,
     compactThreshold: TOKEN_LIMIT,
     usagePercent: Math.round((totalTokens / CONTEXT_WINDOW) * 100),
-    compactions: compactionCount,
+    pruningCount: counters.pruningCount,
+    compactionCount: counters.compactionCount,
+    compactions: counters.compactionCount,
+    sessionKey: key,
   };
+}
+
+function countPrunedToolResults(before: AgentMessage[], after: AgentMessage[]): number {
+  let count = 0;
+  for (let i = 0; i < Math.min(before.length, after.length); i++) {
+    if (before[i] !== after[i] && (before[i] as Message).role === "toolResult") count++;
+  }
+  return count;
+}
+
+function messageText(msg: AgentMessage): string {
+  const m = msg as Message;
+  if (m.role === "user") {
+    if (typeof m.content === "string") return m.content;
+    return m.content
+      .filter((c) => c.type === "text")
+      .map((c) => (c as any).text)
+      .join("\n");
+  }
+  if (m.role === "assistant") {
+    return m.content
+      .filter((c) => c.type === "text")
+      .map((c) => (c as any).text)
+      .join("\n");
+  }
+  return m.content
+    .filter((c) => c.type === "text")
+    .map((c) => (c as any).text)
+    .join("\n");
+}
+
+function appendTextToUserMessage(msg: AgentMessage, note: string): AgentMessage {
+  const m = msg as Message;
+  if (m.role !== "user") return msg;
+  if (typeof m.content === "string") {
+    return { ...m, content: `${m.content}\n\n${note}` } as AgentMessage;
+  }
+  return { ...m, content: [...m.content, { type: "text", text: note }] } as AgentMessage;
+}
+
+function attachContextNoteToLatestUser(messages: AgentMessage[], note: string): AgentMessage[] {
+  const trimmedNote = note.length > CONTEXT_NOTE_MAX_CHARS
+    ? `${note.slice(0, CONTEXT_NOTE_MAX_CHARS)}\n[context note truncated]`
+    : note;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i] as Message).role !== "user") continue;
+    const out = messages.slice();
+    out[i] = appendTextToUserMessage(messages[i], trimmedNote);
+    return out;
+  }
+  return messages;
+}
+
+export function includeActiveBrief(messages: AgentMessage[], sessionKey?: string): AgentMessage[] {
+  const key = normalizeSessionKey(sessionKey);
+  const brief = getSessionBrief(key);
+  if (!brief?.brief_md?.trim()) return messages;
+
+  const latestUser = [...messages].reverse().find((msg) => (msg as Message).role === "user");
+  const latestUserText = latestUser ? messageText(latestUser).trim() : "";
+  if (brief.last_user_req && latestUserText && latestUserText === brief.last_user_req.trim()) {
+    return messages;
+  }
+
+  const note = [
+    "[Active session brief, for continuity only. The user's current request appears above.]",
+    brief.brief_md.trim(),
+    brief.current_objective ? `Current objective: ${brief.current_objective}` : "",
+    brief.suggested_next.length > 0 ? `Suggested next: ${brief.suggested_next.join("; ")}` : "",
+    brief.open_blockers ? `Open blockers: ${brief.open_blockers}` : "",
+  ].filter(Boolean).join("\n");
+  return attachContextNoteToLatestUser(messages, note);
 }
 
 /**
@@ -165,20 +262,34 @@ export function pruneStaleToolResults(
   return changed ? out : messages;
 }
 
-export async function transformContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
+export async function transformContext(messages: AgentMessage[], sessionKey?: string): Promise<AgentMessage[]> {
   logConfigOnce();
+  const key = normalizeSessionKey(sessionKey);
+  const counters = getCounters(key);
 
   // Cheap in-session pruning first — runs every turn, strips old toolResult
   // bodies so a long merge/debug session doesn't re-bill huge diffs forever.
+  const beforePrune = messages;
   messages = pruneStaleToolResults(messages);
+  const pruned = countPrunedToolResults(beforePrune, messages);
+  if (pruned > 0) {
+    counters.pruningCount += pruned;
+    traceContextEvent("context.pruning", {
+      "session.id": key,
+      "prov.session.id": key,
+      "context.pruned_tool_results": pruned,
+      "context.pruning_count": counters.pruningCount,
+    }, () => undefined);
+    log("info", `Context pruning: pruned ${pruned} stale tool results for session ${key}`);
+  }
 
   const totalTokens = messages.reduce((sum, m) => sum + estimateMessageTokens(m), 0);
 
   if (totalTokens <= TOKEN_LIMIT) {
-    return messages;
+    return includeActiveBrief(messages, key);
   }
 
-  log("info", `Context compaction triggered: ${totalTokens} tokens > ${TOKEN_LIMIT} threshold (${messages.length} messages)`);
+  log("info", `Context compaction triggered for session ${key}: ${totalTokens} tokens > ${TOKEN_LIMIT} threshold (${messages.length} messages)`);
 
   // Find how many messages to compact — keep removing from front until under 50% of window
   const targetTokens = Math.floor(CONTEXT_WINDOW * 0.5);
@@ -300,15 +411,21 @@ export async function transformContext(messages: AgentMessage[]): Promise<AgentM
   const summaryText = llmSummary
     ? `[CONTEXT SUMMARY — compacted at ${timestamp}]\n\n${llmSummary}`
     : buildHeuristicSummary(toCompact);
-  const summaryMessage: AgentMessage = {
-    role: "user",
-    content: summaryText,
-    timestamp: Date.now(),
-  };
 
-  compactionCount++;
-  const newTokens = toKeep.reduce((sum, m) => sum + estimateMessageTokens(m), 0) + estimateMessageTokens(summaryMessage);
-  log("info", `Context compacted: ${toCompact.length} messages → summary. ${messages.length} → ${toKeep.length + 1} messages. ${totalTokens} → ~${newTokens} tokens. Compaction #${compactionCount}`);
+  counters.compactionCount++;
+  const compacted = attachContextNoteToLatestUser(toKeep, summaryText);
+  const withBrief = includeActiveBrief(compacted, key);
+  const newTokens = withBrief.reduce((sum, m) => sum + estimateMessageTokens(m), 0);
+  traceContextEvent("context.compaction", {
+    "session.id": key,
+    "prov.session.id": key,
+    "context.tokens_before": totalTokens,
+    "context.tokens_after": newTokens,
+    "context.messages_before": messages.length,
+    "context.messages_after": withBrief.length,
+    "context.compaction_count": counters.compactionCount,
+  }, () => undefined);
+  log("info", `Context compacted for session ${key}: ${toCompact.length} messages summarized. ${messages.length} → ${withBrief.length} messages. ${totalTokens} → ~${newTokens} tokens. Compaction #${counters.compactionCount}`);
 
-  return [summaryMessage, ...toKeep];
+  return withBrief;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,11 +2,168 @@ import type { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { getState, setState } from "./task-journal.js";
 import { log } from "./logger.js";
+import { getAgentWeaveSession } from "./agentweave-context.js";
+import { traceContextEvent } from "./tracing.js";
 
 const SESSION_KEY = "session_messages";
 const MAX_TOOL_RESULT_CHARS = 2000; // truncate tool results to prevent session bloat
 const MAX_SESSION_MESSAGES = 20; // only save the most recent messages
-let saveTimer: ReturnType<typeof setTimeout> | null = null;
+const ACTIVE_BRIEF_MAX_CHARS = 2048;
+const ACTIVE_BRIEF_LIST_MAX = 8;
+const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export interface SessionOptions {
+  sessionKey?: string;
+}
+
+export interface SessionBrief {
+  brief_md: string;
+  last_user_req: string;
+  current_objective: string;
+  suggested_next: string[];
+  files_touched: string[];
+  open_blockers: string;
+  updated_at: number;
+}
+
+function normalizeSessionKey(sessionKey?: string): string {
+  return sessionKey || getAgentWeaveSession() || "max-main";
+}
+
+function scopedStateKey(prefix: string, sessionKey?: string): string {
+  return `${prefix}:${normalizeSessionKey(sessionKey)}`;
+}
+
+function truncateText(text: string, maxChars: number): string {
+  const compact = text.replace(/\s+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+  if (compact.length <= maxChars) return compact;
+  return `${compact.slice(0, Math.max(0, maxChars - 24)).trimEnd()}\n...[truncated]`;
+}
+
+function uniqueCapped(values: string[], max = ACTIVE_BRIEF_LIST_MAX): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+function extractText(msg: AgentMessage): string {
+  const m = msg as any;
+  if (m.role === "user") {
+    if (typeof m.content === "string") return m.content;
+    if (Array.isArray(m.content)) {
+      return m.content
+        .filter((c: any) => c.type === "text")
+        .map((c: any) => c.text)
+        .join("\n");
+    }
+  }
+  if ((m.role === "assistant" || m.role === "toolResult") && Array.isArray(m.content)) {
+    return m.content
+      .filter((c: any) => c.type === "text")
+      .map((c: any) => c.text)
+      .join("\n");
+  }
+  return "";
+}
+
+function extractFilesTouched(messages: AgentMessage[]): string[] {
+  const text = messages.map(extractText).join("\n");
+  const matches = text.match(/(?:\/[\w.-]+)+(?:\.[\w.-]+)?|(?:src|tests|docs|scripts|dist)\/[^\s'"`)]+/g) ?? [];
+  return uniqueCapped(matches.map((m) => m.replace(/[),.;:]+$/, "")));
+}
+
+export function capSessionBrief(brief: Omit<SessionBrief, "updated_at"> & Partial<Pick<SessionBrief, "updated_at">>): SessionBrief {
+  return {
+    brief_md: truncateText(brief.brief_md || "", ACTIVE_BRIEF_MAX_CHARS),
+    last_user_req: truncateText(brief.last_user_req || "", 500),
+    current_objective: truncateText(brief.current_objective || "", 300),
+    suggested_next: uniqueCapped((brief.suggested_next || []).map((v) => truncateText(v, 180)), 3),
+    files_touched: uniqueCapped(brief.files_touched || []),
+    open_blockers: truncateText(brief.open_blockers || "", 300),
+    updated_at: brief.updated_at || Date.now(),
+  };
+}
+
+export function getSessionBrief(sessionKey?: string): SessionBrief | null {
+  try {
+    const json = getState(scopedStateKey("session_brief", sessionKey));
+    if (!json) return null;
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== "object") return null;
+    return capSessionBrief({
+      brief_md: String(parsed.brief_md || ""),
+      last_user_req: String(parsed.last_user_req || ""),
+      current_objective: String(parsed.current_objective || ""),
+      suggested_next: Array.isArray(parsed.suggested_next) ? parsed.suggested_next.map(String) : [],
+      files_touched: Array.isArray(parsed.files_touched) ? parsed.files_touched.map(String) : [],
+      open_blockers: String(parsed.open_blockers || ""),
+      updated_at: typeof parsed.updated_at === "number" ? parsed.updated_at : Date.now(),
+    });
+  } catch (e: any) {
+    log("warn", `Failed to read session brief: ${e.message}`);
+    return null;
+  }
+}
+
+export function setSessionBrief(brief: Omit<SessionBrief, "updated_at"> & Partial<Pick<SessionBrief, "updated_at">>, sessionKey?: string): SessionBrief {
+  const key = normalizeSessionKey(sessionKey);
+  const capped = capSessionBrief({ ...brief, updated_at: Date.now() });
+  setState(scopedStateKey("session_brief", key), JSON.stringify(capped));
+  traceContextEvent("context.brief_update", {
+    "session.id": key,
+    "prov.session.id": key,
+    "context.brief_chars": capped.brief_md.length,
+    "context.brief_files": capped.files_touched.length,
+  }, () => undefined);
+  log("info", `Session brief updated for ${key} (${capped.brief_md.length} chars)`);
+  return capped;
+}
+
+export function buildSessionBrief(messages: AgentMessage[]): SessionBrief | null {
+  const latestUser = [...messages].reverse().find((msg) => (msg as any).role === "user");
+  if (!latestUser) return null;
+  const latestAssistant = [...messages].reverse().find((msg) => (msg as any).role === "assistant");
+  const lastUserReq = truncateText(extractText(latestUser), 500);
+  const assistantText = latestAssistant ? truncateText(extractText(latestAssistant), 900) : "";
+  const toolNames = uniqueCapped(messages
+    .filter((msg) => (msg as any).role === "toolResult" && (msg as any).toolName)
+    .map((msg) => String((msg as any).toolName)));
+  const filesTouched = extractFilesTouched(messages);
+  const briefLines = [
+    lastUserReq ? `Latest request: ${lastUserReq}` : "",
+    assistantText ? `Latest response/outcome: ${assistantText}` : "",
+    toolNames.length > 0 ? `Recent tools: ${toolNames.join(", ")}` : "",
+    filesTouched.length > 0 ? `Files touched: ${filesTouched.join(", ")}` : "",
+  ].filter(Boolean);
+  if (briefLines.length === 0) return null;
+  return capSessionBrief({
+    brief_md: briefLines.join("\n"),
+    last_user_req: lastUserReq,
+    current_objective: lastUserReq,
+    suggested_next: [],
+    files_touched: filesTouched,
+    open_blockers: "",
+  });
+}
+
+export function updateSessionBriefFromMessages(messages: AgentMessage[], sessionKey?: string): SessionBrief | null {
+  const key = normalizeSessionKey(sessionKey);
+  try {
+    const brief = buildSessionBrief(messages);
+    if (!brief) return null;
+    return setSessionBrief(brief, key);
+  } catch (e: any) {
+    log("warn", `Session brief update failed for ${key}: ${e.message}`);
+    return null;
+  }
+}
 
 /**
  * Truncate large tool results, strip thinking blocks, and limit message count
@@ -53,19 +210,25 @@ function trimForStorage(messages: AgentMessage[]): AgentMessage[] {
 /**
  * Save agent messages to SQLite (debounced 500ms).
  */
-export function saveSession(agent: Agent): void {
-  if (saveTimer) clearTimeout(saveTimer);
-  saveTimer = setTimeout(() => {
+export function saveSession(agent: Agent, options: SessionOptions = {}): void {
+  const sessionKey = normalizeSessionKey(options.sessionKey);
+  const existingTimer = saveTimers.get(sessionKey);
+  if (existingTimer) clearTimeout(existingTimer);
+  const timer = setTimeout(() => {
+    saveTimers.delete(sessionKey);
     try {
       const { messages: repaired } = repairErroredAssistantTurns(agent.state.messages);
       const trimmed = trimForStorage(repaired);
       const json = JSON.stringify(trimmed);
+      setState(scopedStateKey(SESSION_KEY, sessionKey), json);
       setState(SESSION_KEY, json);
-      log("info", `Session saved (${trimmed.length} of ${agent.state.messages.length} messages)`);
+      updateSessionBriefFromMessages(trimmed, sessionKey);
+      log("info", `Session saved for ${sessionKey} (${trimmed.length} of ${agent.state.messages.length} messages)`);
     } catch (e: any) {
       log("error", `Failed to save session: ${e.message}`);
     }
   }, 500);
+  saveTimers.set(sessionKey, timer);
 }
 
 /**
@@ -97,9 +260,10 @@ function repairErroredAssistantTurns(messages: AgentMessage[]): { messages: Agen
  * Restore agent messages from SQLite.
  * Returns the number of messages restored.
  */
-export function restoreSession(agent: Agent): number {
+export function restoreSession(agent: Agent, options: SessionOptions = {}): number {
   try {
-    const json = getState(SESSION_KEY);
+    const sessionKey = normalizeSessionKey(options.sessionKey);
+    const json = getState(scopedStateKey(SESSION_KEY, sessionKey)) ?? getState(SESSION_KEY);
     if (!json) return 0;
 
     const parsed = JSON.parse(json);
@@ -108,9 +272,9 @@ export function restoreSession(agent: Agent): number {
     const { messages, repaired } = repairErroredAssistantTurns(parsed);
     agent.state.messages = messages;
     if (repaired > 0) {
-      log("info", `Session restored (${messages.length} messages, repaired ${repaired} errored assistant turns)`);
+      log("info", `Session restored for ${sessionKey} (${messages.length} messages, repaired ${repaired} errored assistant turns)`);
     } else {
-      log("info", `Session restored (${messages.length} messages)`);
+      log("info", `Session restored for ${sessionKey} (${messages.length} messages)`);
     }
     return messages.length;
   } catch (e: any) {
@@ -122,10 +286,20 @@ export function restoreSession(agent: Agent): number {
 /**
  * Clear saved session from SQLite.
  */
-export function clearSession(): void {
+export function clearSession(options: SessionOptions = {}): void {
   try {
-    setState(SESSION_KEY, "[]");
-    log("info", "Session cleared");
+    const sessionKey = normalizeSessionKey(options.sessionKey);
+    setState(scopedStateKey(SESSION_KEY, sessionKey), "[]");
+    setState(scopedStateKey("session_brief", sessionKey), JSON.stringify(capSessionBrief({
+      brief_md: "",
+      last_user_req: "",
+      current_objective: "",
+      suggested_next: [],
+      files_touched: [],
+      open_blockers: "",
+    })));
+    if (sessionKey === "max-main") setState(SESSION_KEY, "[]");
+    log("info", `Session cleared for ${sessionKey}`);
   } catch (e: any) {
     log("error", `Failed to clear session: ${e.message}`);
   }

--- a/src/telegram-bot.ts
+++ b/src/telegram-bot.ts
@@ -247,9 +247,11 @@ export function createTelegramBot(agent: Agent): Bot {
 
   bot.command("clear", async (ctx) => {
     if (!isAllowed(ctx)) return;
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
     conversationHistory.length = 0;
     agent.clearMessages();
-    clearSession();
+    clearSession({ sessionKey: `tg-${chatId}` });
     await ctx.reply("Conversation context cleared.");
   });
 
@@ -271,6 +273,8 @@ export function createTelegramBot(agent: Agent): Bot {
     }
 
     log("info", `Telegram message from ${ctx.from?.id}: ${text.slice(0, 100)}${images?.length ? ` (+${images.length} image${images.length > 1 ? "s" : ""})` : ""}`);
+    const sessionKey = `tg-${ctx.chat?.id ?? ctx.from?.id ?? "unknown"}`;
+    agent.sessionId = sessionKey;
 
     conversationHistory.push({ role: "user", text, timestamp: Date.now() });
     trimHistory();
@@ -572,7 +576,7 @@ export function createTelegramBot(agent: Agent): Bot {
       trimHistory();
 
       updateTaskStatus(task.id, "completed", { response: responseText.slice(0, 500) });
-      saveSession(agent);
+      saveSession(agent, { sessionKey });
       await writeMemoryEvent(`Telegram conversation with user ${ctx.from?.id}: "${text.slice(0, 80)}"`);
     } catch (e: any) {
       if (editTimer) clearInterval(editTimer);

--- a/src/tools/context-info.ts
+++ b/src/tools/context-info.ts
@@ -11,13 +11,15 @@ export function createContextInfoTool(agent: Agent): AgentTool {
     description: "Get details about the current conversation context: token usage, message count, context window capacity, and compaction history.",
     parameters: Type.Object({}),
     execute: async () => {
-      const stats = getContextStats(agent.state.messages);
+      const stats = getContextStats(agent.state.messages, agent.sessionId);
       const lines = [
+        `Session: ${stats.sessionKey}`,
         `Context window: ${(stats.contextWindow / 1000).toFixed(0)}K tokens`,
         `Estimated usage: ~${(stats.totalTokens / 1000).toFixed(1)}K tokens (${stats.usagePercent}%)`,
-        `Compact threshold: ${(stats.compactThreshold / 1000).toFixed(0)}K tokens (80%)`,
+        `Compact threshold: ${(stats.compactThreshold / 1000).toFixed(0)}K tokens`,
         `Messages: ${stats.messageCount}`,
-        `Compactions so far: ${stats.compactions}`,
+        `Tool results pruned: ${stats.pruningCount}`,
+        `Compactions so far: ${stats.compactionCount}`,
         `Model: ${agent.state.model.id}`,
         `Thinking: ${agent.state.thinkingLevel}`,
       ];

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -2,7 +2,6 @@ import { AgentWeaveConfig, traceTool, withSpan } from "agentweave";
 import {
   PROV_ACTIVITY_TYPE, ACTIVITY_AGENT_TURN,
   PROV_AGENT_ID, PROV_WAS_ASSOCIATED_WITH,
-  PROV_AGENT_TYPE, AGENT_TYPE_MAIN,
 } from "agentweave";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { log } from "./logger.js";
@@ -62,9 +61,21 @@ export function traceAgentTurn<T>(
     [PROV_ACTIVITY_TYPE]: ACTIVITY_AGENT_TURN,
     [PROV_AGENT_ID]: "max-v1",
     [PROV_WAS_ASSOCIATED_WITH]: "max-v1",
-    [PROV_AGENT_TYPE]: AGENT_TYPE_MAIN,
+    "prov.agent.type": "main",
     ...(meta?.sessionId ? { 'session.id': meta.sessionId, 'prov.session.id': meta.sessionId } : {}),
     ...(meta?.telegramMessageId ? { 'telegram.message_id': String(meta.telegramMessageId) } : {}),
     ...(meta?.chatId ? { 'telegram.chat_id': String(meta.chatId) } : {}),
   }, () => fn());
+}
+
+export function traceContextEvent<T>(
+  name: "context.pruning" | "context.compaction" | "context.brief_update",
+  attrs: Record<string, string | number | boolean | undefined>,
+  fn: () => T
+): T {
+  if (!AgentWeaveConfig.enabled) return fn();
+  const cleanAttrs = Object.fromEntries(
+    Object.entries(attrs).filter(([, value]) => value !== undefined)
+  ) as Record<string, string | number | boolean>;
+  return withSpan(name, cleanAttrs, fn as any) as T;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -87,7 +87,9 @@ async function main() {
       }
     }
 
+    const activeSessionKey = delegatedSessionId || (parentSessionId ? `max-a2a-${taskId}` : "max-main");
     const agent = await createAgent();
+    agent.sessionId = activeSessionKey;
     let responseText = "";
     let budgetExceeded = false;
 
@@ -120,7 +122,7 @@ async function main() {
     unsub();
 
     if (budgetExceeded) {
-      saveSession(agent);
+      saveSession(agent, { sessionKey: activeSessionKey });
       emitSessionArtifact({
         topic: taskLabel || text.slice(0, 80),
         projects: inferProjectsFromText(text),
@@ -151,7 +153,7 @@ async function main() {
     if (!responseText) {
       const lastMsg: any = agent.state.messages[agent.state.messages.length - 1];
       if (lastMsg?.role === "assistant" && lastMsg.stopReason === "error" && lastMsg.errorMessage) {
-        saveSession(agent);
+        saveSession(agent, { sessionKey: activeSessionKey });
         emitSessionArtifact({
           topic: taskLabel || text.slice(0, 80),
           projects: inferProjectsFromText(text),
@@ -167,7 +169,7 @@ async function main() {
       }
     }
 
-    saveSession(agent);
+    saveSession(agent, { sessionKey: activeSessionKey });
     emitSessionArtifact({
       topic: taskLabel || text.slice(0, 80),
       projects: inferProjectsFromText(text),

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,5 +1,23 @@
-import { describe, it, expect } from "@jest/globals";
-import { pruneStaleToolResults } from "../src/context.js";
+import { describe, it, expect, beforeEach, afterAll } from "@jest/globals";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { includeActiveBrief, pruneStaleToolResults, transformContext, getContextStats } from "../src/context.js";
+import { _resetDbForTest } from "../src/task-journal.js";
+import { getSessionBrief, setSessionBrief } from "../src/session.js";
+
+let tmpRoot: string | null = null;
+
+beforeEach(() => {
+  if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "max-context-"));
+  process.env.MAX_DB_PATH = path.join(tmpRoot, "journal.db");
+  _resetDbForTest();
+});
+
+afterAll(() => {
+  if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+});
 
 function mkUser(text: string): any {
   return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() };
@@ -114,5 +132,83 @@ describe("pruneStaleToolResults", () => {
     expect(out[1]).toBe(msgs[1]);
     expect(out[3]).toBe(msgs[3]);
     expect(out[4]).toBe(msgs[4]);
+  });
+});
+
+describe("active session brief", () => {
+  it("stores capped per-session briefs", () => {
+    const brief = setSessionBrief({
+      brief_md: "A".repeat(3000),
+      last_user_req: "latest ask",
+      current_objective: "continue task",
+      suggested_next: ["one", "two", "three", "four"],
+      files_touched: ["src/context.ts", "src/context.ts", "tests/context.test.ts"],
+      open_blockers: "",
+    }, "session-a");
+
+    expect(brief.brief_md.length).toBeLessThanOrEqual(2048);
+    expect(brief.suggested_next).toEqual(["one", "two", "three"]);
+    expect(brief.files_touched).toEqual(["src/context.ts", "tests/context.test.ts"]);
+    expect(getSessionBrief("session-a")?.brief_md).toBe(brief.brief_md);
+    expect(getSessionBrief("session-b")).toBeNull();
+  });
+
+  it("appends the brief after the latest real user text", () => {
+    setSessionBrief({
+      brief_md: "Need to finish the context PR.",
+      last_user_req: "older ask",
+      current_objective: "ship the PR",
+      suggested_next: ["run tests"],
+      files_touched: ["src/context.ts"],
+      open_blockers: "",
+    }, "brief-session");
+
+    const msgs = [mkUser("current ask")];
+    const out = includeActiveBrief(msgs, "brief-session") as any[];
+
+    expect(out).not.toBe(msgs);
+    expect(out[0].content[0].text).toBe("current ask");
+    expect(out[0].content[1].text).toContain("Active session brief");
+    expect(out[0].content[1].text).toContain("Need to finish the context PR.");
+  });
+
+  it("excludes an empty or same-turn brief", async () => {
+    const msgs = [mkUser("current ask")];
+    expect(includeActiveBrief(msgs, "empty-session")).toBe(msgs);
+
+    setSessionBrief({
+      brief_md: "Current turn was already summarized.",
+      last_user_req: "current ask",
+      current_objective: "current ask",
+      suggested_next: [],
+      files_touched: [],
+      open_blockers: "",
+    }, "same-turn");
+
+    expect(includeActiveBrief(msgs, "same-turn")).toBe(msgs);
+    await expect(transformContext(msgs, "same-turn")).resolves.toBe(msgs);
+  });
+});
+
+describe("context stats", () => {
+  it("reports per-session pruning counters", async () => {
+    const msgs = [
+      mkUser("u1"),
+      mkAssistantToolCall("run_shell", "t1"),
+      mkToolResult("run_shell", "t1", "x".repeat(5000)),
+      mkUser("u2"),
+      mkUser("u3"),
+      mkUser("u4"),
+      mkUser("u5"),
+    ];
+
+    await transformContext(msgs, "stats-a");
+    const statsA = getContextStats(msgs, "stats-a");
+    const statsB = getContextStats(msgs, "stats-b");
+
+    expect(statsA.sessionKey).toBe("stats-a");
+    expect(statsA.pruningCount).toBe(1);
+    expect(statsA.compactionCount).toBe(0);
+    expect(statsB.pruningCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- store scoped session messages and capped active briefs under per-session state keys while retaining legacy fallback
- include active briefs/compaction summaries by appending context notes to the latest real user turn, keeping the current request previewable instead of inserting synthetic stale user messages
- add per-session context counters for token estimates, tool-result pruning, and compactions, with AgentWeave/log spans for pruning, compaction, and brief updates
- wire A2A, worker, and Telegram save paths to pass current session metadata where available

Fixes arniesaha/agent-max#47
Fixes arniesaha/agent-max#48

## Validation
- PASS: NODE_OPTIONS='--experimental-vm-modules' /home/Arnab/.nvm/versions/node/v24.13.0/bin/node ./node_modules/jest/bin/jest.js --runTestsByPath tests/context.test.ts
- PARTIAL: full Jest and tsc are blocked in this local checkout because the existing node_modules is missing the declared ignore package/types; unrelated suites otherwise passed until tests importing src/tools/ignore.ts compiled.