### PR TITLE
Fix session isolation and trace attribution

### DIFF
--- a/src/a2a-server.ts
+++ b/src/a2a-server.ts
@@ -13,13 +13,14 @@ import {
   advanceReportedSeq,
   setActualCost,
 } from "./task-journal.js";
-import { setAgentWeaveSession, resetAgentWeaveSession } from "./agentweave-context.js";
+import { withSessionContext } from "./agentweave-context.js";
 import { log } from "./logger.js";
-import { saveSession } from "./session.js";
+import { saveSession, restoreSession } from "./session.js";
 import { extractAssistantTextFromTurn, extractErrorFromTurn } from "./response.js";
 import type { WorkerProgressEvent } from "./worker.js";
 import { relayTaskUpdateToTelegram, relayJobCompletionToTelegram } from "./telegram-notify.js";
 import { receiveCallback } from "./tools/claude-subagent.js";
+import { MAIN_SESSION_CONTEXT, a2aSessionContext, previewInput } from "./session-context.js";
 
 const A2A_PORT = parseInt(process.env.A2A_PORT || "8770", 10);
 const A2A_SHARED_SECRET = process.env.A2A_SHARED_SECRET || "";
@@ -244,8 +245,15 @@ export function createA2AServer(agent: Agent): express.Express {
         return;
       }
 
+      const sessionContext = a2aSessionContext({
+        taskId: task.id,
+        delegatedSessionId,
+        parentSessionId,
+        taskLabel: taskLabel || `a2a from ${callerAgentId || "nix"}`,
+        latestInputPreview: previewInput(text),
+      });
+
       if (parentSessionId) {
-        const sessionId = delegatedSessionId || `max-a2a-${task.id}`;
         try {
           await fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
             method: "POST",
@@ -254,18 +262,19 @@ export function createA2AServer(agent: Agent): express.Express {
               ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
             },
             body: JSON.stringify({
-              session_id: sessionId,
+              session_id: sessionContext.sessionId,
               parent_session_id: parentSessionId,
-              task_label: taskLabel || `a2a from ${callerAgentId || "nix"}`,
+              task_label: sessionContext.taskLabel,
               agent_type: "delegated",
             }),
           });
-          log("info", `AgentWeave session set: ${sessionId} (parent: ${parentSessionId})`);
-          setAgentWeaveSession(sessionId);
+          log("info", `AgentWeave session set: ${sessionContext.sessionId} (parent: ${parentSessionId})`);
         } catch (e: any) {
           log("warn", `AgentWeave session set failed: ${e.message}`);
         }
       }
+
+      restoreSession(agent, sessionContext.sessionKey);
 
       // Execute sync task within the incoming trace context as well
       const executeSyncTask = async () => {
@@ -288,7 +297,7 @@ export function createA2AServer(agent: Agent): express.Express {
           ? extractErrorFromTurn(agent.state.messages as any, turnStartIndex)
           : null;
 
-        saveSession(agent);
+        saveSession(agent, sessionContext.sessionKey);
 
         if (llmError) {
           log("warn", `LLM error during A2A sync task ${task.id}: ${llmError}`);
@@ -316,7 +325,7 @@ export function createA2AServer(agent: Agent): express.Express {
         }
       };
 
-      await context.with(incomingContext, executeSyncTask);
+      await context.with(incomingContext, () => withSessionContext(sessionContext, executeSyncTask));
     } catch (e: any) {
       agent.abort();
       log("error", `A2A task error: ${e.message}`);
@@ -328,7 +337,6 @@ export function createA2AServer(agent: Agent): express.Express {
       });
     } finally {
       if (parentSessionId && String(req.query.sync || "false").toLowerCase() === "true") {
-        resetAgentWeaveSession();
         fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
           method: "POST",
           headers: {
@@ -336,7 +344,7 @@ export function createA2AServer(agent: Agent): express.Express {
             ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
           },
           body: JSON.stringify({
-            session_id: "max-main",
+            session_id: MAIN_SESSION_CONTEXT.sessionId,
             parent_session_id: "",
             task_label: "",
             agent_type: "main",
@@ -364,6 +372,8 @@ export function createA2AServer(agent: Agent): express.Express {
 
       const task = createTask("a2a_stream", "tui", { text });
       updateTaskStatus(task.id, "working");
+      const sessionContext = { ...MAIN_SESSION_CONTEXT, surface: "tui" as const, latestInputPreview: previewInput(text) };
+      restoreSession(agent, sessionContext.sessionKey);
 
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
@@ -394,9 +404,9 @@ export function createA2AServer(agent: Agent): express.Express {
         }
       });
 
-      await agent.prompt(text);
+      await withSessionContext(sessionContext, () => agent.prompt(text));
       unsub();
-      saveSession(agent);
+      saveSession(agent, sessionContext.sessionKey);
 
       updateTaskStatus(task.id, "completed", { response: "(streamed)" });
       sendEvent("task_end", { taskId: task.id, status: "completed" });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -20,6 +20,8 @@ import { transformContext } from "./context.js";
 import { traceTools } from "./tracing.js";
 import { restoreSession } from "./session.js";
 import { checkPermission } from "./permissions.js";
+import { getSessionContext, setFallbackSessionContext } from "./agentweave-context.js";
+import { MAIN_SESSION_CONTEXT, type SessionContext } from "./session-context.js";
 
 /**
  * Core tools — always registered. Small, general-purpose surface the model
@@ -113,7 +115,30 @@ function createDefaultModel(defaultModel: string) {
   return model;
 }
 
-export async function createAgent(): Promise<Agent> {
+
+export function agentWeaveHeadersForSession(
+  activeSession: SessionContext,
+  opts: { muxEnabled: boolean; muxApiKey?: string; proxyToken?: string }
+): Record<string, string> {
+  const agentType = activeSession.surface === "a2a" || activeSession.surface === "worker" || activeSession.surface === "subagent"
+    ? "delegated"
+    : "main";
+  return {
+    "X-AgentWeave-Agent-Id": "max-v1",
+    "X-AgentWeave-Agent-Type": agentType,
+    "X-AgentWeave-Session-Id": activeSession.sessionId,
+    "X-AgentWeave-Project": "max",
+    ...(activeSession.parentSessionId ? { "X-AgentWeave-Parent-Session-Id": activeSession.parentSessionId } : {}),
+    ...(activeSession.taskLabel ? { "X-AgentWeave-Task-Label": activeSession.taskLabel } : {}),
+    ...(activeSession.latestInputPreview ? { "X-AgentWeave-Input-Preview": activeSession.latestInputPreview } : {}),
+    "X-Runtime": "agent-max",
+    ...(opts.muxEnabled && opts.muxApiKey ? { Authorization: `Bearer ${opts.muxApiKey}` } : {}),
+    ...(!opts.muxEnabled && opts.proxyToken ? { "X-AgentWeave-Proxy-Token": opts.proxyToken } : {}),
+  };
+}
+
+export async function createAgent(sessionContext: SessionContext = MAIN_SESSION_CONTEXT): Promise<Agent> {
+  setFallbackSessionContext(sessionContext);
   const defaultModel = process.env.DEFAULT_MODEL || "gemini-2.5-pro";
   const muxEnabled = process.env.MUX_ENABLED === "true";
   const model = muxEnabled ? createMuxModel(defaultModel) : createDefaultModel(defaultModel);
@@ -126,20 +151,16 @@ export async function createAgent(): Promise<Agent> {
   // Only send AgentWeave proxy token for non-Mux paths to avoid colliding with Mux auth.
   const proxyToken = process.env.AGENTWEAVE_PROXY_TOKEN;
   const muxApiKey = process.env.MUX_API_KEY;
-  const agentWeaveStreamFn: typeof streamSimple = (m, ctx, opts) =>
-    streamSimple(m, ctx, {
+  const agentWeaveStreamFn: typeof streamSimple = (m, ctx, opts) => {
+    const activeSession = getSessionContext();
+    return streamSimple(m, ctx, {
       ...opts,
       headers: {
         ...opts?.headers,
-        "X-AgentWeave-Agent-Id": "max-v1",
-        "X-AgentWeave-Agent-Type": "main",
-        "X-AgentWeave-Session-Id": "max-main",
-        "X-AgentWeave-Project": "max",
-        "X-Runtime": "agent-max",
-        ...(muxEnabled && muxApiKey ? { Authorization: `Bearer ${muxApiKey}` } : {}),
-        ...(!muxEnabled && proxyToken ? { "X-AgentWeave-Proxy-Token": proxyToken } : {}),
+        ...agentWeaveHeadersForSession(activeSession, { muxEnabled, muxApiKey, proxyToken }),
       },
     });
+  };
 
   const agent = new Agent({
     initialState: {
@@ -180,7 +201,7 @@ export async function createAgent(): Promise<Agent> {
   agent.state.tools = allTools;
 
   // Restore previous session messages
-  restoreSession(agent);
+  restoreSession(agent, sessionContext.sessionKey);
 
   return agent;
 }

--- a/src/agentweave-context.ts
+++ b/src/agentweave-context.ts
@@ -1,18 +1,29 @@
-/**
- * Shared AgentWeave session context.
- * Updated by a2a-server.ts when processing A2A tasks.
- * Read by nix-relay.ts when invoking delegate_to_nix.
- */
-let _currentSession = "max-main";
+import { AsyncLocalStorage } from "async_hooks";
+import { MAIN_SESSION_CONTEXT, type SessionContext } from "./session-context.js";
+
+const sessionStorage = new AsyncLocalStorage<SessionContext>();
+let fallbackSessionContext: SessionContext = MAIN_SESSION_CONTEXT;
+
+export function withSessionContext<T>(sessionContext: SessionContext, fn: () => T): T {
+  return sessionStorage.run(sessionContext, fn);
+}
+
+export function getSessionContext(): SessionContext {
+  return sessionStorage.getStore() || fallbackSessionContext;
+}
+
+export function setFallbackSessionContext(sessionContext: SessionContext): void {
+  fallbackSessionContext = sessionContext;
+}
 
 export function setAgentWeaveSession(sessionId: string): void {
-  _currentSession = sessionId;
+  fallbackSessionContext = { ...fallbackSessionContext, sessionId };
 }
 
 export function getAgentWeaveSession(): string {
-  return _currentSession;
+  return getSessionContext().sessionId;
 }
 
 export function resetAgentWeaveSession(): void {
-  _currentSession = "max-main";
+  fallbackSessionContext = MAIN_SESSION_CONTEXT;
 }

--- a/src/session-context.ts
+++ b/src/session-context.ts
@@ -1,0 +1,55 @@
+export type SessionSurface = "main" | "telegram" | "a2a" | "worker" | "tui" | "subagent";
+
+export interface SessionContext {
+  sessionKey: string;
+  sessionId: string;
+  surface: SessionSurface;
+  taskId?: string;
+  parentSessionId?: string;
+  taskLabel?: string;
+  latestInputPreview?: string;
+}
+
+export const MAIN_SESSION_KEY = "max:main";
+export const MAIN_SESSION_ID = "max-main";
+
+export const MAIN_SESSION_CONTEXT: SessionContext = {
+  sessionKey: MAIN_SESSION_KEY,
+  sessionId: MAIN_SESSION_ID,
+  surface: "main",
+};
+
+export function previewInput(input: string, maxChars = 240): string {
+  return input.replace(/\s+/g, " ").trim().slice(0, maxChars);
+}
+
+export function telegramSessionContext(chatId: number | string, latestInputPreview?: string): SessionContext {
+  const id = String(chatId);
+  const sessionKey = `telegram:direct:${id}`;
+  return {
+    sessionKey,
+    sessionId: sessionKey,
+    surface: "telegram",
+    latestInputPreview,
+  };
+}
+
+export function a2aSessionContext(args: {
+  taskId: string;
+  delegatedSessionId?: string;
+  parentSessionId?: string;
+  taskLabel?: string;
+  latestInputPreview?: string;
+  surface?: "a2a" | "worker";
+}): SessionContext {
+  const sessionId = args.delegatedSessionId || `max-a2a-${args.taskId}`;
+  return {
+    sessionKey: `a2a:${args.taskId}`,
+    sessionId,
+    surface: args.surface || "a2a",
+    taskId: args.taskId,
+    parentSessionId: args.parentSessionId,
+    taskLabel: args.taskLabel,
+    latestInputPreview: args.latestInputPreview,
+  };
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,11 +2,33 @@ import type { Agent } from "@mariozechner/pi-agent-core";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { getState, setState } from "./task-journal.js";
 import { log } from "./logger.js";
+import { MAIN_SESSION_KEY } from "./session-context.js";
 
-const SESSION_KEY = "session_messages";
+const LEGACY_SESSION_KEY = "session_messages";
 const MAX_TOOL_RESULT_CHARS = 2000; // truncate tool results to prevent session bloat
 const MAX_SESSION_MESSAGES = 20; // only save the most recent messages
-let saveTimer: ReturnType<typeof setTimeout> | null = null;
+const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+export function sessionStorageKey(sessionKey: string = MAIN_SESSION_KEY): string {
+  return `session_messages:${sessionKey}`;
+}
+
+function loadSessionJson(sessionKey: string): string | undefined {
+  const scopedKey = sessionStorageKey(sessionKey);
+  const scoped = getState(scopedKey);
+  if (scoped !== undefined) return scoped;
+
+  if (sessionKey === MAIN_SESSION_KEY) {
+    const legacy = getState(LEGACY_SESSION_KEY);
+    if (legacy !== undefined) {
+      setState(scopedKey, legacy);
+      log("info", `Migrated legacy ${LEGACY_SESSION_KEY} to ${scopedKey}`);
+    }
+    return legacy;
+  }
+
+  return undefined;
+}
 
 /**
  * Truncate large tool results, strip thinking blocks, and limit message count
@@ -14,7 +36,6 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null;
  * so restored sessions produce valid API requests.
  */
 function trimForStorage(messages: AgentMessage[]): AgentMessage[] {
-  // Find a starting point within the last MAX_SESSION_MESSAGES that begins with a user message
   let startIdx = Math.max(0, messages.length - MAX_SESSION_MESSAGES);
   while (startIdx < messages.length && (messages[startIdx] as any).role !== "user") {
     startIdx++;
@@ -36,12 +57,9 @@ function trimForStorage(messages: AgentMessage[]): AgentMessage[] {
       });
       return { ...m, content: trimmedContent };
     }
-    // Strip thinking blocks entirely — they contain signatures that break
-    // when truncated, and the model doesn't need them for continuity.
     if (m.role === "assistant" && Array.isArray(m.content)) {
       const filtered = m.content.filter((c: any) => c.type !== "thinking");
       if (filtered.length === 0) {
-        // Thinking-only response — replace with a minimal text block
         return { ...m, content: [{ type: "text", text: "(thinking)" }] };
       }
       return { ...m, content: filtered };
@@ -53,29 +71,28 @@ function trimForStorage(messages: AgentMessage[]): AgentMessage[] {
 /**
  * Save agent messages to SQLite (debounced 500ms).
  */
-export function saveSession(agent: Agent): void {
-  if (saveTimer) clearTimeout(saveTimer);
-  saveTimer = setTimeout(() => {
+export function saveSession(agent: Agent, sessionKey: string = MAIN_SESSION_KEY): void {
+  const existing = saveTimers.get(sessionKey);
+  if (existing) clearTimeout(existing);
+  const timer = setTimeout(() => {
     try {
       const { messages: repaired } = repairErroredAssistantTurns(agent.state.messages);
       const trimmed = trimForStorage(repaired);
       const json = JSON.stringify(trimmed);
-      setState(SESSION_KEY, json);
-      log("info", `Session saved (${trimmed.length} of ${agent.state.messages.length} messages)`);
+      setState(sessionStorageKey(sessionKey), json);
+      log("info", `Session ${sessionKey} saved (${trimmed.length} of ${agent.state.messages.length} messages)`);
     } catch (e: any) {
-      log("error", `Failed to save session: ${e.message}`);
+      log("error", `Failed to save session ${sessionKey}: ${e.message}`);
+    } finally {
+      saveTimers.delete(sessionKey);
     }
   }, 500);
+  saveTimers.set(sessionKey, timer);
 }
 
 /**
  * Rewrite assistant messages whose stopReason is "error"/"aborted" but whose
- * content is actually non-empty. This undoes damage from a prior mux regression
- * that passed Anthropic stop_reason values (e.g. "end_turn") through as
- * OpenAI finish_reason, causing pi-ai's mapStopReason to throw after the text
- * had already streamed. The assistant message was persisted with valid content
- * but stopReason="error", which transform-messages.js then dropped on every
- * subsequent turn — producing the +1/turn context bleed.
+ * content is actually non-empty.
  */
 function repairErroredAssistantTurns(messages: AgentMessage[]): { messages: AgentMessage[]; repaired: number } {
   let repaired = 0;
@@ -97,24 +114,31 @@ function repairErroredAssistantTurns(messages: AgentMessage[]): { messages: Agen
  * Restore agent messages from SQLite.
  * Returns the number of messages restored.
  */
-export function restoreSession(agent: Agent): number {
+export function restoreSession(agent: Agent, sessionKey: string = MAIN_SESSION_KEY): number {
   try {
-    const json = getState(SESSION_KEY);
-    if (!json) return 0;
+    const json = loadSessionJson(sessionKey);
+    if (!json) {
+      agent.state.messages = [];
+      return 0;
+    }
 
     const parsed = JSON.parse(json);
-    if (!Array.isArray(parsed) || parsed.length === 0) return 0;
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      agent.state.messages = [];
+      return 0;
+    }
 
     const { messages, repaired } = repairErroredAssistantTurns(parsed);
     agent.state.messages = messages;
     if (repaired > 0) {
-      log("info", `Session restored (${messages.length} messages, repaired ${repaired} errored assistant turns)`);
+      log("info", `Session ${sessionKey} restored (${messages.length} messages, repaired ${repaired} errored assistant turns)`);
     } else {
-      log("info", `Session restored (${messages.length} messages)`);
+      log("info", `Session ${sessionKey} restored (${messages.length} messages)`);
     }
     return messages.length;
   } catch (e: any) {
-    log("error", `Failed to restore session: ${e.message}`);
+    log("error", `Failed to restore session ${sessionKey}: ${e.message}`);
+    agent.state.messages = [];
     return 0;
   }
 }
@@ -122,11 +146,14 @@ export function restoreSession(agent: Agent): number {
 /**
  * Clear saved session from SQLite.
  */
-export function clearSession(): void {
+export function clearSession(sessionKey: string = MAIN_SESSION_KEY): void {
   try {
-    setState(SESSION_KEY, "[]");
-    log("info", "Session cleared");
+    const existing = saveTimers.get(sessionKey);
+    if (existing) clearTimeout(existing);
+    saveTimers.delete(sessionKey);
+    setState(sessionStorageKey(sessionKey), "[]");
+    log("info", `Session ${sessionKey} cleared`);
   } catch (e: any) {
-    log("error", `Failed to clear session: ${e.message}`);
+    log("error", `Failed to clear session ${sessionKey}: ${e.message}`);
   }
 }

--- a/src/telegram-bot.ts
+++ b/src/telegram-bot.ts
@@ -5,8 +5,10 @@ import { writeMemoryEvent } from "./memory.js";
 import { createTask, updateTaskStatus, getRecentTasks } from "./task-journal.js";
 import { log } from "./logger.js";
 import { traceAgentTurn } from "./tracing.js";
-import { saveSession, clearSession } from "./session.js";
+import { saveSession, clearSession, restoreSession } from "./session.js";
 import { extractAssistantTextFromTurn, extractErrorFromTurn } from "./response.js";
+import { withSessionContext } from "./agentweave-context.js";
+import { previewInput, telegramSessionContext, type SessionContext } from "./session-context.js";
 
 // ── Deduplication — Issue #2 ─────────────────────────────────────────────────
 const processedUpdateIds = new Set<number>();
@@ -248,13 +250,15 @@ export function createTelegramBot(agent: Agent): Bot {
   bot.command("clear", async (ctx) => {
     if (!isAllowed(ctx)) return;
     conversationHistory.length = 0;
+    const session = telegramSessionContext(ctx.chat.id);
+    clearSession(session.sessionKey);
     agent.clearMessages();
-    clearSession();
     await ctx.reply("Conversation context cleared.");
   });
 
   // Core message handler — processes text with optional images
-  async function handleMessage(ctx: Context, text: string, images?: { type: "image"; data: string; mimeType: string }[]) {
+  async function handleMessage(ctx: Context, text: string, images?: { type: "image"; data: string; mimeType: string }[], session?: SessionContext) {
+    const sessionContext = session || telegramSessionContext(ctx.chat!.id, previewInput(text));
     // If agent is already running a request, abort it and wait for completion
     if (agent.state.isStreaming) {
       log("info", "Aborting previous agent run before starting new request");
@@ -270,6 +274,7 @@ export function createTelegramBot(agent: Agent): Bot {
       }
     }
 
+    restoreSession(agent, sessionContext.sessionKey);
     log("info", `Telegram message from ${ctx.from?.id}: ${text.slice(0, 100)}${images?.length ? ` (+${images.length} image${images.length > 1 ? "s" : ""})` : ""}`);
 
     conversationHistory.push({ role: "user", text, timestamp: Date.now() });
@@ -572,7 +577,7 @@ export function createTelegramBot(agent: Agent): Bot {
       trimHistory();
 
       updateTaskStatus(task.id, "completed", { response: responseText.slice(0, 500) });
-      saveSession(agent);
+      saveSession(agent, sessionContext.sessionKey);
       await writeMemoryEvent(`Telegram conversation with user ${ctx.from?.id}: "${text.slice(0, 80)}"`);
     } catch (e: any) {
       if (editTimer) clearInterval(editTimer);
@@ -601,12 +606,12 @@ export function createTelegramBot(agent: Agent): Bot {
       log("warn", `Duplicate update ${updateId} ignored`);
       return;
     }
-    const sessionId = `tg-${ctx.chat.id}`;
+    const session = telegramSessionContext(ctx.chat.id, previewInput(ctx.message.text));
     const telegramMessageId = ctx.message.message_id;
     const chatId = ctx.chat.id;
-    await traceAgentTurn("handleMessage", async () => {
-      await handleMessage(ctx, ctx.message.text);
-    }, { sessionId, telegramMessageId, chatId });
+    await withSessionContext(session, () => traceAgentTurn("handleMessage", async () => {
+      await handleMessage(ctx, ctx.message.text, undefined, session);
+    }, { sessionId: session.sessionId, telegramMessageId, chatId, latestInputPreview: session.latestInputPreview }));
   });
 
   // Photo messages (with optional caption)
@@ -619,7 +624,7 @@ export function createTelegramBot(agent: Agent): Bot {
     }
 
     const caption = ctx.message.caption || "What do you see in this image?";
-    const sessionId = `tg-${ctx.chat.id}`;
+    const session = telegramSessionContext(ctx.chat.id, previewInput(caption));
     const telegramMessageId = ctx.message.message_id;
     const chatId = ctx.chat.id;
 
@@ -640,9 +645,9 @@ export function createTelegramBot(agent: Agent): Bot {
       const ext = file.file_path?.split(".").pop()?.toLowerCase() || "jpg";
       const mimeType = ext === "png" ? "image/png" : ext === "gif" ? "image/gif" : ext === "webp" ? "image/webp" : "image/jpeg";
 
-      await traceAgentTurn("handleMessage", async () => {
-        await handleMessage(ctx, caption, [{ type: "image", data: base64, mimeType }]);
-      }, { sessionId, telegramMessageId, chatId });
+      await withSessionContext(session, () => traceAgentTurn("handleMessage", async () => {
+        await handleMessage(ctx, caption, [{ type: "image", data: base64, mimeType }], session);
+      }, { sessionId: session.sessionId, telegramMessageId, chatId, latestInputPreview: session.latestInputPreview }));
     } catch (e: any) {
       log("error", `Failed to process photo: ${e.message}`);
       await ctx.reply(`Failed to process image: ${e.message}`);

--- a/src/tools/nix-relay.ts
+++ b/src/tools/nix-relay.ts
@@ -2,7 +2,7 @@ import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { context, propagation } from "@opentelemetry/api";
 import { log } from "../logger.js";
-import { getAgentWeaveSession } from "../agentweave-context.js";
+import { getSessionContext } from "../agentweave-context.js";
 
 const NIX_A2A_URL = process.env.NIX_A2A_URL || "http://localhost:8771";
 const A2A_SHARED_SECRET = process.env.A2A_SHARED_SECRET || "";
@@ -22,6 +22,7 @@ export const delegateToNix: AgentTool = {
   execute: async (_id, params: any, signal) => {
     const { task, skill_id } = params;
     const taskId = crypto.randomUUID();
+    const activeSession = getSessionContext();
 
     try {
       // Submit task async — Nix returns immediately with status "submitted"
@@ -32,7 +33,8 @@ export const delegateToNix: AgentTool = {
           ...authHeaders,
           ...(() => { const h: Record<string, string> = {}; propagation.inject(context.active(), h); return h; })(),
           // AgentWeave session attribution for trace propagation
-          "X-AgentWeave-Parent-Session-Id": getAgentWeaveSession(),
+          "X-AgentWeave-Parent-Session-Id": activeSession.sessionId,
+          "X-AgentWeave-Parent-Session-Key": activeSession.sessionKey,
           "X-AgentWeave-Delegated-Session-Id": `nix-a2a-${taskId}`,
           "X-AgentWeave-Agent-Id": process.env.AGENTWEAVE_AGENT_ID || "max-v1",
           "X-AgentWeave-Task-Label": `a2a:${skill_id || "general"}:${task.slice(0, 50)}`,

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -55,7 +55,7 @@ export function traceTools(tools: AgentTool[]): AgentTool[] {
 export function traceAgentTurn<T>(
   name: string,
   fn: () => T | Promise<T>,
-  meta?: { sessionId?: string; telegramMessageId?: number; chatId?: number }
+  meta?: { sessionId?: string; telegramMessageId?: number; chatId?: number; latestInputPreview?: string }
 ): T | Promise<T> {
   if (!AgentWeaveConfig.enabled) return fn();
   return withSpan(`agent.${name}`, {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,10 +2,11 @@ import { parentPort, workerData } from "worker_threads";
 import { context, propagation } from "@opentelemetry/api";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { createAgent } from "./agent.js";
-import { setAgentWeaveSession, resetAgentWeaveSession } from "./agentweave-context.js";
+import { withSessionContext } from "./agentweave-context.js";
 import { log } from "./logger.js";
 import { saveSession } from "./session.js";
 import { emitSessionArtifact, inferProjectsFromText } from "./session-emit.js";
+import { MAIN_SESSION_CONTEXT, a2aSessionContext, previewInput } from "./session-context.js";
 
 const AGENTWEAVE_MAX_PROXY = process.env.AGENTWEAVE_PROXY_URL || "http://arnabsnas.local:30400";
 
@@ -65,8 +66,16 @@ async function main() {
   try {
     await postProgress({ type: "progress", taskId, message: "Worker started" });
 
+    const sessionContext = a2aSessionContext({
+      taskId,
+      delegatedSessionId,
+      parentSessionId,
+      taskLabel: taskLabel || `a2a from ${callerAgentId || "nix"}`,
+      latestInputPreview: previewInput(text),
+      surface: "worker",
+    });
+
     if (parentSessionId) {
-      const sessionId = delegatedSessionId || `max-a2a-${taskId}`;
       try {
         await fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
           method: "POST",
@@ -75,19 +84,18 @@ async function main() {
             ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
           },
           body: JSON.stringify({
-            session_id: sessionId,
+            session_id: sessionContext.sessionId,
             parent_session_id: parentSessionId,
-            task_label: taskLabel || `a2a from ${callerAgentId || "nix"}`,
+            task_label: sessionContext.taskLabel,
             agent_type: "delegated",
           }),
         });
-        setAgentWeaveSession(sessionId);
       } catch (e: any) {
         log("warn", `Worker AgentWeave session set failed: ${e.message}`);
       }
     }
 
-    const agent = await createAgent();
+    const agent = await createAgent(sessionContext);
     let responseText = "";
     let budgetExceeded = false;
 
@@ -116,11 +124,11 @@ async function main() {
       }
     });
 
-    await agent.prompt(text);
+    await withSessionContext(sessionContext, () => agent.prompt(text));
     unsub();
 
     if (budgetExceeded) {
-      saveSession(agent);
+      saveSession(agent, sessionContext.sessionKey);
       emitSessionArtifact({
         topic: taskLabel || text.slice(0, 80),
         projects: inferProjectsFromText(text),
@@ -151,7 +159,7 @@ async function main() {
     if (!responseText) {
       const lastMsg: any = agent.state.messages[agent.state.messages.length - 1];
       if (lastMsg?.role === "assistant" && lastMsg.stopReason === "error" && lastMsg.errorMessage) {
-        saveSession(agent);
+        saveSession(agent, sessionContext.sessionKey);
         emitSessionArtifact({
           topic: taskLabel || text.slice(0, 80),
           projects: inferProjectsFromText(text),
@@ -167,7 +175,7 @@ async function main() {
       }
     }
 
-    saveSession(agent);
+    saveSession(agent, sessionContext.sessionKey);
     emitSessionArtifact({
       topic: taskLabel || text.slice(0, 80),
       projects: inferProjectsFromText(text),
@@ -194,7 +202,6 @@ async function main() {
     });
   } finally {
     if (parentSessionId) {
-      resetAgentWeaveSession();
       const AGENTWEAVE_PROXY_TOKEN = process.env.AGENTWEAVE_PROXY_TOKEN;
       fetch(`${AGENTWEAVE_MAX_PROXY}/session`, {
         method: "POST",
@@ -203,7 +210,7 @@ async function main() {
           ...(AGENTWEAVE_PROXY_TOKEN ? { Authorization: `Bearer ${AGENTWEAVE_PROXY_TOKEN}` } : {}),
         },
         body: JSON.stringify({
-          session_id: "max-main",
+          session_id: MAIN_SESSION_CONTEXT.sessionId,
           parent_session_id: "",
           task_label: "",
           agent_type: "main",

--- a/tests/a2a-callback.test.ts
+++ b/tests/a2a-callback.test.ts
@@ -24,12 +24,15 @@ jest.unstable_mockModule("../src/task-journal.js", () => ({
 jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
 jest.unstable_mockModule("../src/session.js", () => ({
   saveSession: jest.fn(),
+  restoreSession: jest.fn(),
   loadSession: jest.fn().mockReturnValue(null),
 }));
 jest.unstable_mockModule("../src/agentweave-context.js", () => ({
   setAgentWeaveSession: jest.fn(),
   resetAgentWeaveSession: jest.fn(),
   getAgentWeaveSession: jest.fn().mockReturnValue("max-main"),
+  withSessionContext: jest.fn((_ctx, fn: any) => fn()),
+  getSessionContext: jest.fn().mockReturnValue({ sessionKey: "max:main", sessionId: "max-main", surface: "main" }),
 }));
 jest.unstable_mockModule("../src/response.js", () => ({
   extractAssistantTextFromTurn: jest.fn().mockReturnValue(""),

--- a/tests/a2a-trace-propagation.test.ts
+++ b/tests/a2a-trace-propagation.test.ts
@@ -33,12 +33,15 @@ jest.unstable_mockModule("../src/task-journal.js", () => ({
 jest.unstable_mockModule("../src/logger.js", () => ({ log: jest.fn() }));
 jest.unstable_mockModule("../src/session.js", () => ({
   saveSession: jest.fn(),
+  restoreSession: jest.fn(),
   loadSession: jest.fn().mockReturnValue(null),
 }));
 jest.unstable_mockModule("../src/agentweave-context.js", () => ({
   setAgentWeaveSession: jest.fn(),
   resetAgentWeaveSession: jest.fn(),
   getAgentWeaveSession: jest.fn().mockReturnValue("max-main"),
+  withSessionContext: jest.fn((_ctx, fn: any) => fn()),
+  getSessionContext: jest.fn().mockReturnValue({ sessionKey: "max:main", sessionId: "max-main", surface: "main" }),
 }));
 jest.unstable_mockModule("../src/response.js", () => ({
   extractAssistantTextFromTurn: jest.fn().mockReturnValue(""),
@@ -60,6 +63,8 @@ const SECRET = "test-trace-secret";
 process.env.A2A_SHARED_SECRET = SECRET;
 
 const { createA2AServer } = await import("../src/a2a-server.js");
+const { Worker } = await import("worker_threads");
+const { saveSession, restoreSession } = await import("../src/session.js");
 
 function makeAgent() {
   return {
@@ -196,5 +201,57 @@ describe("POST /tasks — traceparent HTTP acceptance", () => {
       body: taskBody("req-5"),
     });
     expect(res.body.result?.status?.state).toBe("working");
+  });
+
+  it("passes isolated session context to async A2A workers without saving the shared agent", async () => {
+    (Worker as jest.Mock).mockClear();
+    (saveSession as jest.Mock).mockClear();
+    const app = createA2AServer(makeAgent());
+    const res = await callEndpoint(app, "POST", "/tasks", {
+      auth: `Bearer ${SECRET}`,
+      headers: {
+        "x-agentweave-parent-session-id": "nix-session-123",
+        "x-agentweave-delegated-session-id": "max-from-nix-456",
+        "x-agentweave-agent-id": "nix-v1",
+        "x-agentweave-task-label": "delegation-from-nix",
+      },
+      body: taskBody("req-worker"),
+    });
+
+    expect(res.status).toBe(202);
+    expect(saveSession).not.toHaveBeenCalled();
+    const workerOptions = (Worker as jest.Mock).mock.calls[0][1] as any;
+    expect(workerOptions.workerData).toMatchObject({
+      taskId: "task-001",
+      text: "test task",
+      parentSessionId: "nix-session-123",
+      delegatedSessionId: "max-from-nix-456",
+      callerAgentId: "nix-v1",
+      taskLabel: "delegation-from-nix",
+    });
+  });
+
+  it("restores and saves only the sync A2A task bucket", async () => {
+    (saveSession as jest.Mock).mockClear();
+    (restoreSession as jest.Mock).mockClear();
+    const agent = makeAgent();
+    agent.prompt = jest.fn(async () => {
+      agent.state.messages = [{ role: "user", content: "test task" }, { role: "assistant", content: [{ type: "text", text: "ok" }] }];
+    });
+    const app = createA2AServer(agent);
+    const res = await callEndpoint(app, "POST", "/tasks?sync=true", {
+      auth: `Bearer ${SECRET}`,
+      headers: {
+        "x-agentweave-parent-session-id": "nix-session-123",
+        "x-agentweave-delegated-session-id": "max-from-nix-789",
+        "x-agentweave-agent-id": "nix-v1",
+        "x-agentweave-task-label": "sync-from-nix",
+      },
+      body: taskBody("req-sync"),
+    });
+
+    expect(res.status).toBe(200);
+    expect(restoreSession).toHaveBeenCalledWith(agent, "a2a:task-001");
+    expect(saveSession).toHaveBeenCalledWith(agent, "a2a:task-001");
   });
 });

--- a/tests/agent-headers.test.ts
+++ b/tests/agent-headers.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "@jest/globals";
+import { agentWeaveHeadersForSession } from "../src/agent.js";
+
+describe("AgentWeave session headers", () => {
+  it("attributes main/TUI traffic to max-main", () => {
+    const headers = agentWeaveHeadersForSession(
+      { sessionKey: "max:main", sessionId: "max-main", surface: "main", latestInputPreview: "hello" },
+      { muxEnabled: false, proxyToken: "proxy-token" }
+    );
+
+    expect(headers["X-AgentWeave-Session-Id"]).toBe("max-main");
+    expect(headers["X-AgentWeave-Agent-Type"]).toBe("main");
+    expect(headers["X-AgentWeave-Input-Preview"]).toBe("hello");
+    expect(headers["X-AgentWeave-Proxy-Token"]).toBe("proxy-token");
+  });
+
+  it("attributes Telegram traffic to the active chat session", () => {
+    const headers = agentWeaveHeadersForSession(
+      { sessionKey: "telegram:direct:42", sessionId: "telegram:direct:42", surface: "telegram" },
+      { muxEnabled: true, muxApiKey: "mux-key" }
+    );
+
+    expect(headers["X-AgentWeave-Session-Id"]).toBe("telegram:direct:42");
+    expect(headers["X-AgentWeave-Agent-Type"]).toBe("main");
+    expect(headers.Authorization).toBe("Bearer mux-key");
+    expect(headers["X-AgentWeave-Proxy-Token"]).toBeUndefined();
+  });
+
+  it("attributes delegated A2A traffic to the delegated session and parent", () => {
+    const headers = agentWeaveHeadersForSession(
+      {
+        sessionKey: "a2a:task-001",
+        sessionId: "max-from-nix-123",
+        surface: "a2a",
+        parentSessionId: "nix-session-abc",
+        taskLabel: "sync-from-nix",
+      },
+      { muxEnabled: false }
+    );
+
+    expect(headers["X-AgentWeave-Session-Id"]).toBe("max-from-nix-123");
+    expect(headers["X-AgentWeave-Parent-Session-Id"]).toBe("nix-session-abc");
+    expect(headers["X-AgentWeave-Agent-Type"]).toBe("delegated");
+    expect(headers["X-AgentWeave-Task-Label"]).toBe("sync-from-nix");
+  });
+});

--- a/tests/session-context.test.ts
+++ b/tests/session-context.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const { withSessionContext, getSessionContext, getAgentWeaveSession } = await import("../src/agentweave-context.js");
+const { delegateToNix } = await import("../src/tools/nix-relay.js");
+
+describe("active session context", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses async-local session context for AgentWeave session lookup", async () => {
+    await withSessionContext({ sessionKey: "telegram:direct:42", sessionId: "telegram:direct:42", surface: "telegram" }, async () => {
+      expect(getSessionContext().sessionKey).toBe("telegram:direct:42");
+      expect(getAgentWeaveSession()).toBe("telegram:direct:42");
+    });
+  });
+
+  it("delegate_to_nix propagates the active parent session id and key", async () => {
+    const fetchMock = jest.fn(async (_url: string, opts: any) => {
+      if (opts.method === "POST") {
+        return { ok: true, json: async () => ({ id: "nix-task-1", status: "completed", result: { reply: "done" } }) } as any;
+      }
+      return { ok: true, json: async () => ({ id: "nix-task-1", status: "completed", result: { reply: "done" } }) } as any;
+    });
+    const originalFetch = global.fetch;
+    (global as any).fetch = fetchMock;
+    try {
+      await withSessionContext({ sessionKey: "telegram:direct:42", sessionId: "telegram:direct:42", surface: "telegram" }, async () => {
+        const result = await delegateToNix.execute("tool-1", { task: "look this up", skill_id: "recall_search" } as any);
+        expect(result.details?.success).toBe(true);
+      });
+    } finally {
+      (global as any).fetch = originalFetch;
+    }
+
+    const postHeaders = fetchMock.mock.calls[0][1].headers;
+    expect(postHeaders["X-AgentWeave-Parent-Session-Id"]).toBe("telegram:direct:42");
+    expect(postHeaders["X-AgentWeave-Parent-Session-Key"]).toBe("telegram:direct:42");
+    expect(postHeaders["X-AgentWeave-Delegated-Session-Id"]).toMatch(/^nix-a2a-/);
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const { _resetDbForTest, setState, getState } = await import("../src/task-journal.js");
+const { saveSession, restoreSession, clearSession, sessionStorageKey } = await import("../src/session.js");
+
+function agentWith(messages: any[] = []) {
+  return { state: { messages } } as any;
+}
+
+let tmpPath: string;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  tmpPath = join(mkdtempSync(join(tmpdir(), "agent-max-session-test-")), "journal.db");
+  process.env.MAX_DB_PATH = tmpPath;
+  _resetDbForTest();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  _resetDbForTest();
+  delete process.env.MAX_DB_PATH;
+  rmSync(tmpPath.replace(/journal\.db$/, ""), { recursive: true, force: true });
+});
+
+describe("session persistence buckets", () => {
+  it("saves and restores isolated Telegram and A2A buckets", async () => {
+    saveSession(agentWith([{ role: "user", content: "telegram hello" }]), "telegram:direct:111");
+    saveSession(agentWith([{ role: "user", content: "a2a hello" }]), "a2a:task-001");
+    await jest.advanceTimersByTimeAsync(600);
+
+    const telegramAgent = agentWith();
+    const a2aAgent = agentWith();
+
+    expect(restoreSession(telegramAgent, "telegram:direct:111")).toBe(1);
+    expect(restoreSession(a2aAgent, "a2a:task-001")).toBe(1);
+    expect(telegramAgent.state.messages[0].content).toBe("telegram hello");
+    expect(a2aAgent.state.messages[0].content).toBe("a2a hello");
+  });
+
+  it("migrates the legacy global session_messages key to max:main", () => {
+    const legacy = JSON.stringify([{ role: "user", content: "legacy main" }]);
+    setState("session_messages", legacy);
+
+    const mainAgent = agentWith();
+    expect(restoreSession(mainAgent)).toBe(1);
+
+    expect(mainAgent.state.messages[0].content).toBe("legacy main");
+    expect(getState(sessionStorageKey("max:main"))).toBe(legacy);
+  });
+
+  it("clears only the requested bucket", async () => {
+    saveSession(agentWith([{ role: "user", content: "chat one" }]), "telegram:direct:1");
+    saveSession(agentWith([{ role: "user", content: "chat two" }]), "telegram:direct:2");
+    await jest.advanceTimersByTimeAsync(600);
+
+    clearSession("telegram:direct:1");
+
+    const one = agentWith([{ role: "user", content: "stale" }]);
+    const two = agentWith();
+    expect(restoreSession(one, "telegram:direct:1")).toBe(0);
+    expect(restoreSession(two, "telegram:direct:2")).toBe(1);
+    expect(one.state.messages).toEqual([]);
+    expect(two.state.messages[0].content).toBe("chat two");
+  });
+});


### PR DESCRIPTION
## Summary
- add Max-owned `SessionContext` plumbing with scoped persisted buckets (`session_messages:<sessionKey>`) and legacy `session_messages` migration to `max:main`
- isolate Telegram per chat, sync/async A2A per task, workers per delegated task, and keep TUI/main on `max:main`
- derive AgentWeave/Langfuse attribution headers from the active session context, including parent/task metadata and current input preview where available
- propagate active session id/key through `delegate_to_nix`

Closes #45.
Closes #46.

## Validation
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin /opt/homebrew/bin/npm run build`
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin /opt/homebrew/bin/npm test -- --runInBand`

## Notes
- Did not restart the live `com.arnab.agent-max` service.
