### PR TITLE
fix: sanitize non-Latin-1 chars in AgentWeave headers

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -116,6 +116,21 @@ function createDefaultModel(defaultModel: string) {
 }
 
 
+// HTTP header values must be Latin-1 (a ByteString, char codes 0-255). User
+// input from mobile keyboards routinely contains smart quotes, em-dashes, and
+// emoji (code points > 255), which make fetch throw "Cannot convert argument to
+// a ByteString …" before the request is even sent. Transliterate the common
+// punctuation and strip anything else down to printable ASCII so diagnostic
+// headers carrying user text can never break the LLM call.
+export function toHeaderValue(value: string): string {
+  return value
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/[–—]/g, "-")
+    .replace(/…/g, "...")
+    .replace(/[^\x20-\x7E]/g, "");
+}
+
 export function agentWeaveHeadersForSession(
   activeSession: SessionContext,
   opts: { muxEnabled: boolean; muxApiKey?: string; proxyToken?: string }
@@ -123,7 +138,7 @@ export function agentWeaveHeadersForSession(
   const agentType = activeSession.surface === "a2a" || activeSession.surface === "worker" || activeSession.surface === "subagent"
     ? "delegated"
     : "main";
-  return {
+  const headers: Record<string, string> = {
     "X-AgentWeave-Agent-Id": "max-v1",
     "X-AgentWeave-Agent-Type": agentType,
     "X-AgentWeave-Session-Id": activeSession.sessionId,
@@ -132,9 +147,15 @@ export function agentWeaveHeadersForSession(
     ...(activeSession.taskLabel ? { "X-AgentWeave-Task-Label": activeSession.taskLabel } : {}),
     ...(activeSession.latestInputPreview ? { "X-AgentWeave-Input-Preview": activeSession.latestInputPreview } : {}),
     "X-Runtime": "agent-max",
-    ...(opts.muxEnabled && opts.muxApiKey ? { Authorization: `Bearer ${opts.muxApiKey}` } : {}),
-    ...(!opts.muxEnabled && opts.proxyToken ? { "X-AgentWeave-Proxy-Token": opts.proxyToken } : {}),
   };
+  // Sanitize only the AgentWeave diagnostic headers (which may carry user text).
+  // Auth tokens are added afterward untouched.
+  for (const key of Object.keys(headers)) {
+    headers[key] = toHeaderValue(headers[key]);
+  }
+  if (opts.muxEnabled && opts.muxApiKey) headers.Authorization = `Bearer ${opts.muxApiKey}`;
+  if (!opts.muxEnabled && opts.proxyToken) headers["X-AgentWeave-Proxy-Token"] = opts.proxyToken;
+  return headers;
 }
 
 export async function createAgent(sessionContext: SessionContext = MAIN_SESSION_CONTEXT): Promise<Agent> {

--- a/tests/agent-headers.test.ts
+++ b/tests/agent-headers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { agentWeaveHeadersForSession } from "../src/agent.js";
+import { agentWeaveHeadersForSession, toHeaderValue } from "../src/agent.js";
 
 describe("AgentWeave session headers", () => {
   it("attributes main/TUI traffic to max-main", () => {
@@ -42,5 +42,31 @@ describe("AgentWeave session headers", () => {
     expect(headers["X-AgentWeave-Parent-Session-Id"]).toBe("nix-session-abc");
     expect(headers["X-AgentWeave-Agent-Type"]).toBe("delegated");
     expect(headers["X-AgentWeave-Task-Label"]).toBe("sync-from-nix");
+  });
+
+  it("sanitizes non-Latin-1 user input so headers never throw a ByteString error", () => {
+    // U+2019 smart apostrophe (8217) at index 3 of "Let's …" was the original crash.
+    const headers = agentWeaveHeadersForSession(
+      {
+        sessionKey: "telegram:direct:42",
+        sessionId: "telegram:direct:42",
+        surface: "telegram",
+        latestInputPreview: "Let’s debug the ssh skill — try \u{1F600}",
+      },
+      { muxEnabled: false }
+    );
+
+    const preview = headers["X-AgentWeave-Input-Preview"];
+    expect(preview).toBe("Let's debug the ssh skill - try ");
+    // Must be encodable as a real HTTP header (Latin-1 / ByteString).
+    expect(() => new Headers(headers)).not.toThrow();
+    for (const value of Object.values(headers)) {
+      expect(/[^\x20-\x7E]/.test(value)).toBe(false);
+    }
+  });
+
+  it("toHeaderValue transliterates smart punctuation and drops other non-ASCII", () => {
+    expect(toHeaderValue("‘a’ “b” – — …")).toBe("'a' \"b\" - - ...");
+    expect(toHeaderValue("plain ascii")).toBe("plain ascii");
   });
 });


### PR DESCRIPTION
## Problem

A Telegram message starting with **"Let's debug the ssh skill…"** crashed the LLM call with:

> LLM error: Cannot convert argument to a ByteString because the character at index 3 has a value of 8217 which is greater than 255.

The apostrophe in *Let's* was a smart quote (`'` = U+2019 = 8217), auto-inserted by the phone keyboard. Max copies a preview of user input into the `X-AgentWeave-Input-Preview` HTTP header for tracing. HTTP header values are ByteStrings (char codes 0–255), so `fetch` threw **before the request was sent**. Any message containing a smart quote, em-dash, or emoji hit this.

## Fix

- Add `toHeaderValue()` in `src/agent.ts`: transliterates smart quotes/dashes/ellipsis to ASCII and strips remaining non-printable-ASCII.
- Apply to all AgentWeave diagnostic headers (`Input-Preview`, `Task-Label`, session ids). Auth tokens added afterward, untouched.
- Regression test reproducing the original `Let's` (U+2019 at index 3) crash plus emoji.

## Test

`npm test` → 113/113 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnLPYECcGWNP3zPK7JCS3y